### PR TITLE
Fix Post-build Event error

### DIFF
--- a/src/ZLogger/ZLogger.csproj
+++ b/src/ZLogger/ZLogger.csproj
@@ -85,6 +85,6 @@
         <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
 
         <!-- After copy, remove nullable reference -->
-        <Exec Command="dotnet run --no-build -c $(ConfigurationName) --project $(MSBuildProjectDirectory)\..\..\tools\CommandTools\CommandTools.csproj -- remove-nullable-reference -directory $(DestinationRoot)" />
+        <Exec Command="dotnet run --no-build -c $(ConfigurationName) --project $(MSBuildProjectDirectory)\..\..\tools\CommandTools\CommandTools.csproj -- remove-nullable-reference $(DestinationRoot)" />
     </Target>
 </Project>


### PR DESCRIPTION
`-directory` argument causes a build error.
```
1>Start to remove nullable reference.
1>-directory
1>Fail in console app running on Program.RemoveNullableReferenceDefine
1>System.IO.DirectoryNotFoundException: Could not find a part of the path 'D:\Programming\Git\ZLogger\src\ZLogger\-directory'.
1>   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
1>   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
1>   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, Boolean isNormalized, EnumerationOptions options)
1>   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
1>   at System.IO.Enumeration.FileSystemEnumerableFactory.UserFiles(String directory, String expression, EnumerationOptions options)
1>   at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
1>   at System.IO.Directory.EnumerateFiles(String path, String searchPattern, SearchOption searchOption)
1>   at CommandTools.Program.RemoveNullableReferenceDefine(String directory) in D:\Programming\Git\ZLogger\tools\CommandTools\Program.cs:line 58
1>D:\Programming\Git\ZLogger\src\ZLogger\ZLogger.csproj(88,9): error MSB3073: The command "dotnet run --no-build -c Debug --project D:\Programming\Git\ZLogger\src\ZLogger\..\..\tools\CommandTools\CommandTools.csproj -- remove-nullable-reference -directory D:\Programming\Git\ZLogger\src\ZLogger\..\ZLogger.Unity\Assets\Scripts\ZLogger\" exited with code 1.
1>Done building project "ZLogger.csproj" -- FAILED.
2>------ Build started: Project: ConsoleApp, Configuration: Debug Any CPU ------
3>------ Build started: Project: ZLogger.Tests, Configuration: Debug Any CPU ------
4>------ Build started: Project: Benchmark, Configuration: Debug Any CPU ------
3>ZLogger.Tests -> D:\Programming\Git\ZLogger\tests\ZLogger.Tests\bin\Debug\netcoreapp3.1\ZLogger.Tests.dll
4>Benchmark -> D:\Programming\Git\ZLogger\sandbox\Benchmark\bin\Debug\netcoreapp3.1\Benchmark.dll
2>ConsoleApp -> D:\Programming\Git\ZLogger\sandbox\ConsoleApp\bin\Debug\netcoreapp3.1\ConsoleApp.dll
========== Build: 3 succeeded, 1 failed, 1 up-to-date, 0 skipped ==========
```