### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -5,12 +5,12 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-        <PackageReference Include="log4net" Version="2.0.8" />
-        <PackageReference Include="NLog" Version="4.7.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-        <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+        <PackageReference Include="log4net" Version="2.0.11" />
+        <PackageReference Include="NLog" Version="4.7.4" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />


### PR DESCRIPTION
Hi@neuecc, I found an issue in the Benchmark.csproj:

Packages BenchmarkDotNet v0.12.0, log4net v2.0.8, NLog v4.7.0, Serilog.Sinks.Console v3.1.1, Serilog.Sinks.File v4.1.0 and Microsoft.Bcl.AsyncInterfaces v1.1.0 transitively introduce 89 dependencies into ZLogger’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/ZLogger.html)), while BenchmarkDotNet v0.13.0, log4net v2.0.11, NLog v4.7.4, Serilog.Sinks.File v5.0.0, Serilog.Sinks.Console v4.0.0 and Microsoft.Bcl.AsyncInterfaces v1.1.1 can only introduce 51 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/ZLogger_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose