### PR TITLE
Avoid FormatException on ZLog and ZLogWithPayload

### DIFF
--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -287,6 +287,10 @@ namespace MyApp
 
             logger.ZLogInformation("{abc=1}");
 
+            logger.ZLog(LogLevel.Information, "{a}");
+
+            logger.ZLogWithPayload(LogLevel.Debug, new { a = 1 }, "{b}");
+
             // new HoGeMoge().Foo();
 
             //logger.LogDebug("foooooo  {0} {1}", 10, 20);

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerExtensions.cs
@@ -4027,24 +4027,24 @@ namespace ZLogger
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, string message)
         {
-            ZLog<object>(logger, logLevel, default, null, message, null);
+            ZLog(logger, logLevel, default(EventId), default(Exception), message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, string message)
         {
-            ZLog<object>(logger, logLevel, eventId, null, message, null);
+            ZLog(logger, logLevel, eventId, default(Exception), message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, Exception exception, string message)
         {
-            ZLog<object>(logger, logLevel, default, exception, message, null);
+            ZLog(logger, logLevel, default(EventId), exception, message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string message)
         {
-            logger.Log(logLevel, eventId, new FormatLogState<object, object>(null, message, null), exception, (state, ex) =>
+            logger.Log(logLevel, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
-                return state.Format;
+                return state.Message;
             });
         }
 
@@ -4065,9 +4065,9 @@ namespace ZLogger
 
         public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string message)
         {
-            logger.Log(logLevel, eventId, new FormatLogState<TPayload, object>(payload, message, null), exception, (state, ex) =>
+            logger.Log(logLevel, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
-                return message;
+                return state.Message;
             });
         }
 

--- a/src/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger/ZLoggerExtensions.cs
@@ -4027,24 +4027,24 @@ namespace ZLogger
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, string message)
         {
-            ZLog<object>(logger, logLevel, default, null, message, null!);
+            ZLog(logger, logLevel, default(EventId), default(Exception), message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, string message)
         {
-            ZLog<object>(logger, logLevel, eventId, null, message, null!);
+            ZLog(logger, logLevel, eventId, default(Exception), message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, string message)
         {
-            ZLog<object>(logger, logLevel, default, exception, message, null!);
+            ZLog(logger, logLevel, default(EventId), exception, message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string message)
         {
-            logger.Log(logLevel, eventId, new FormatLogState<object, object>(null, message, null!), exception, (state, ex) =>
+            logger.Log(logLevel, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
-                return state.Format;
+                return state.Message;
             });
         }
 
@@ -4065,9 +4065,9 @@ namespace ZLogger
 
         public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string message)
         {
-            logger.Log(logLevel, eventId, new FormatLogState<TPayload, object>(payload, message, null!), exception, (state, ex) =>
+            logger.Log(logLevel, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
-                return message;
+                return state.Message;
             });
         }
 

--- a/src/ZLogger/ZLoggerExtensions.tt
+++ b/src/ZLogger/ZLoggerExtensions.tt
@@ -130,24 +130,24 @@ namespace ZLogger
 <# } #>
         public static void ZLog(this ILogger logger, LogLevel logLevel, string message)
         {
-            ZLog<object>(logger, logLevel, default, null, message, null!);
+            ZLog(logger, logLevel, default(EventId), default(Exception), message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, string message)
         {
-            ZLog<object>(logger, logLevel, eventId, null, message, null!);
+            ZLog(logger, logLevel, eventId, default(Exception), message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, string message)
         {
-            ZLog<object>(logger, logLevel, default, exception, message, null!);
+            ZLog(logger, logLevel, default(EventId), exception, message);
         }
 
         public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string message)
         {
-            logger.Log(logLevel, eventId, new FormatLogState<object, object>(null, message, null!), exception, (state, ex) =>
+            logger.Log(logLevel, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
-                return state.Format;
+                return state.Message;
             });
         }
 
@@ -168,9 +168,9 @@ namespace ZLogger
 
         public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string message)
         {
-            logger.Log(logLevel, eventId, new FormatLogState<TPayload, object>(payload, message, null!), exception, (state, ex) =>
+            logger.Log(logLevel, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
-                return message;
+                return state.Message;
             });
         }
 


### PR DESCRIPTION
I found that the same problem as #11 occurred in ZLog and ZLogWithPayload.

I referred to commit 8256b53 for how to fix it.