### PR TITLE
prototype flattening structured logs to eliminate payload object

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
         <PackageReference Include="log4net" Version="2.0.8" />
         <PackageReference Include="NLog" Version="4.7.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/sandbox/Benchmark/Benchmarks/WriteToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteToFile.cs
@@ -23,10 +23,15 @@ namespace Benchmark.Benchmarks
                 .CreateLogger();
 
             var serviceCollection = new ServiceCollection();
+            void Options(ZLoggerOptions options)
+            {
+                options.EnableStructuredLogging = true;
+                options.PayloadLoggingFormatter = ZLoggerOptions.FlattenedPayloadLoggingFormatter;
+            }
             serviceCollection.AddLogging(options =>
             {
-                options.AddZLoggerFile(@$"C:\logs\{guid}\ZLogger.log");
-                //options.AddZLoggerConsole();
+                options.AddZLoggerFile("/tmp/ZLogger.log", Options);
+                // options.AddZLoggerConsole();
             });
             var serviceProvider = serviceCollection.BuildServiceProvider();
             ZLogger = serviceProvider.GetService<ILoggerProvider>();
@@ -45,6 +50,16 @@ namespace Benchmark.Benchmarks
         public void ZFile()
         {
             ZLoggerLogger.ZLogInformation("foo{0} bar{1} nazo{2}", 10, 20, 30);
+        }
+
+        [Benchmark]
+        public void ZFileWithPayload()
+        {
+            var payload = new {
+                Test = "test",
+                Num = 4
+            };
+            ZLoggerLogger.ZLogInformationWithPayload(payload, "foo{0} bar{1} nazo{2}", 10, 20, 30);
         }
 
 

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/AsyncProcessZLogger.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/AsyncProcessZLogger.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Linq.Expressions;
 using ZLogger.Entries;
@@ -85,7 +85,7 @@ namespace ZLogger
         static class CreateLogEntry<T>
         // where T:IZLoggerState
         {
-            public static readonly Func<T, LogInfo, IZLoggerEntry> factory;
+            public static readonly Func<T, LogInfo, IZLoggerEntry>? factory;
 
             static CreateLogEntry()
             {
@@ -112,7 +112,7 @@ namespace ZLogger
                 }
             }
 
-            static void LogForUnity(System.Reflection.FieldInfo fieldInfo)
+            static void LogForUnity(System.Reflection.FieldInfo? fieldInfo)
             {
 #if UNITY_2018_3_OR_NEWER
                 if(fieldInfo == null)

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/AsyncStreamLineMessageWriter.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/AsyncStreamLineMessageWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/FormatLogEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/FormatLogEntry.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS8601
+﻿#pragma warning disable CS8601
 #pragma warning disable CS8618
 
 using Cysharp.Text;
@@ -16,10 +16,10 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1)
         {
             Payload = payload;
             Format = format;
@@ -87,7 +87,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -117,11 +117,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -129,7 +129,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -159,7 +159,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -194,11 +194,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -206,7 +206,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -217,11 +217,11 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2)
         {
             Payload = payload;
             Format = format;
@@ -292,7 +292,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -322,11 +322,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -334,7 +334,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -364,7 +364,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -399,11 +399,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -411,7 +411,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -422,12 +422,12 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3)
         {
             Payload = payload;
             Format = format;
@@ -501,7 +501,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -531,11 +531,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -543,7 +543,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -573,7 +573,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -608,11 +608,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -620,7 +620,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -631,13 +631,13 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
         public readonly T4 Arg4;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             Payload = payload;
             Format = format;
@@ -714,7 +714,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -744,11 +744,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -756,7 +756,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -786,7 +786,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -821,11 +821,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -833,7 +833,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -844,14 +844,14 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
         public readonly T4 Arg4;
         public readonly T5 Arg5;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             Payload = payload;
             Format = format;
@@ -931,7 +931,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -961,11 +961,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -973,7 +973,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1003,7 +1003,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1038,11 +1038,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1050,7 +1050,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1061,7 +1061,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -1069,7 +1069,7 @@ namespace ZLogger.Entries
         public readonly T5 Arg5;
         public readonly T6 Arg6;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             Payload = payload;
             Format = format;
@@ -1152,7 +1152,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1182,11 +1182,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1194,7 +1194,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1224,7 +1224,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1259,11 +1259,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1271,7 +1271,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1282,7 +1282,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -1291,7 +1291,7 @@ namespace ZLogger.Entries
         public readonly T6 Arg6;
         public readonly T7 Arg7;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             Payload = payload;
             Format = format;
@@ -1377,7 +1377,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1407,11 +1407,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1419,7 +1419,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1449,7 +1449,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1484,11 +1484,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1496,7 +1496,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1507,7 +1507,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -1517,7 +1517,7 @@ namespace ZLogger.Entries
         public readonly T7 Arg7;
         public readonly T8 Arg8;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             Payload = payload;
             Format = format;
@@ -1606,7 +1606,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1636,11 +1636,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1648,7 +1648,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1678,7 +1678,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1713,11 +1713,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1725,7 +1725,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1736,7 +1736,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -1747,7 +1747,7 @@ namespace ZLogger.Entries
         public readonly T8 Arg8;
         public readonly T9 Arg9;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             Payload = payload;
             Format = format;
@@ -1839,7 +1839,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1869,11 +1869,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1881,7 +1881,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1911,7 +1911,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -1946,11 +1946,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -1958,7 +1958,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -1969,7 +1969,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -1981,7 +1981,7 @@ namespace ZLogger.Entries
         public readonly T9 Arg9;
         public readonly T10 Arg10;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             Payload = payload;
             Format = format;
@@ -2076,7 +2076,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2106,11 +2106,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2118,7 +2118,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2148,7 +2148,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2183,11 +2183,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2195,7 +2195,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2206,7 +2206,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -2219,7 +2219,7 @@ namespace ZLogger.Entries
         public readonly T10 Arg10;
         public readonly T11 Arg11;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             Payload = payload;
             Format = format;
@@ -2317,7 +2317,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2347,11 +2347,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2359,7 +2359,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2389,7 +2389,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2424,11 +2424,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2436,7 +2436,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2447,7 +2447,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -2461,7 +2461,7 @@ namespace ZLogger.Entries
         public readonly T11 Arg11;
         public readonly T12 Arg12;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             Payload = payload;
             Format = format;
@@ -2562,7 +2562,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2592,11 +2592,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2604,7 +2604,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2634,7 +2634,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2669,11 +2669,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2681,7 +2681,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2692,7 +2692,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -2707,7 +2707,7 @@ namespace ZLogger.Entries
         public readonly T12 Arg12;
         public readonly T13 Arg13;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             Payload = payload;
             Format = format;
@@ -2811,7 +2811,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2841,11 +2841,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2853,7 +2853,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2883,7 +2883,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -2918,11 +2918,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -2930,7 +2930,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -2941,7 +2941,7 @@ namespace ZLogger.Entries
         public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Format;
+        public readonly string? Format;
         public readonly T1 Arg1;
         public readonly T2 Arg2;
         public readonly T3 Arg3;
@@ -2957,7 +2957,7 @@ namespace ZLogger.Entries
         public readonly T13 Arg13;
         public readonly T14 Arg14;
 
-        public FormatLogState([AllowNull]TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public FormatLogState([AllowNull]TPayload payload, string? format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             Payload = payload;
             Format = format;
@@ -3064,7 +3064,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -3094,11 +3094,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -3106,7 +3106,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }
@@ -3136,7 +3136,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -3171,11 +3171,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
         
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -3183,7 +3183,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/MessageLogEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/MessageLogEntry.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS8601
+﻿#pragma warning disable CS8601
 #pragma warning disable CS8618
 
 using Cysharp.Text;
@@ -18,9 +18,9 @@ namespace ZLogger.Entries
         public static readonly Func<MessageLogState<TPayload>, LogInfo, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
-        public readonly string Message;
+        public readonly string? Message;
 
-        public MessageLogState([AllowNull]TPayload payload, string message)
+        public MessageLogState([AllowNull]TPayload payload, string? message)
         {
             Payload = payload;
             Message = message;
@@ -61,7 +61,7 @@ namespace ZLogger.Entries
             return result;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             if (options.EnableStructuredLogging && jsonWriter != null)
             {
@@ -102,11 +102,11 @@ namespace ZLogger.Entries
         public void Return()
         {
             state = default;
-            LogInfo = default;
+            LogInfo = default!;
             cache.Enqueue(this);
         }
 
-        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload1>(System.Action<IZLoggerEntry, TPayload1, object?> payloadCallback, object? state)
         {
             if (typeof(TPayload1) == typeof(TPayload))
             {
@@ -114,7 +114,7 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return state.Payload;
         }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/StringFormatterEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/StringFormatterEntry.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
@@ -36,7 +36,7 @@ namespace ZLogger.Entries
             return entry;
         }
 
-        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             var str = formatter(state, exception);
 
@@ -68,21 +68,21 @@ namespace ZLogger.Entries
             }
         }
 
-        public object GetPayload()
+        public object? GetPayload()
         {
             return null;
         }
 
-        public void SwitchCasePayload<TPayload>(Action<IZLoggerEntry, TPayload, object> payloadCallback, object state)
+        public void SwitchCasePayload<TPayload>(Action<IZLoggerEntry, TPayload, object?> payloadCallback, object? state)
         {
         }
 
         public void Return()
         {
-            this.state = default;
-            this.LogInfo = default;
-            this.exception = default;
-            this.formatter = default;
+            this.state = default!;
+            this.LogInfo = default!;
+            this.exception = default!;
+            this.formatter = default!;
         }
     }
 }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/IAsyncLogProcessor.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/IAsyncLogProcessor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerEntry.cs
@@ -1,4 +1,4 @@
-using Cysharp.Text;
+﻿using Cysharp.Text;
 using System;
 using System.Buffers;
 using System.Text.Json;
@@ -8,21 +8,21 @@ namespace ZLogger
     public interface IZLoggerEntry
     {
         LogInfo LogInfo { get; }
-        void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter jsonWriter);
-        void SwitchCasePayload<TPayload>(Action<IZLoggerEntry, TPayload, object> payloadCallback, object state);
-        object GetPayload();
+        void FormatUtf8(IBufferWriter<byte> writer, ZLoggerOptions options, Utf8JsonWriter? jsonWriter);
+        void SwitchCasePayload<TPayload>(Action<IZLoggerEntry, TPayload, object?> payloadCallback, object? state);
+        object? GetPayload();
         void Return();
     }
 
     public static class ZLoggerEntryExtensions
     {
-        public static string FormatToString(this IZLoggerEntry entry, ZLoggerOptions options, Utf8JsonWriter jsonWriter)
+        public static string FormatToString(this IZLoggerEntry entry, ZLoggerOptions options, Utf8JsonWriter? jsonWriter)
         {
             var boxedBuilder = (IBufferWriter<byte>)ZString.CreateUtf8StringBuilder();
             try
             {
                 entry.FormatUtf8(boxedBuilder, options, jsonWriter);
-                return boxedBuilder.ToString();
+                return boxedBuilder.ToString()!;
             }
             finally
             {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerState.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerState.cs
@@ -1,4 +1,4 @@
-namespace ZLogger
+﻿namespace ZLogger
 {
     public interface IZLoggerState
     {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/LogInfo.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/LogInfo.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Text.Json;
 
@@ -10,9 +10,9 @@ namespace ZLogger
         public readonly DateTimeOffset Timestamp;
         public readonly LogLevel LogLevel;
         public readonly EventId EventId;
-        public readonly Exception Exception;
+        public readonly Exception? Exception;
 
-        public LogInfo(string categoryName, DateTimeOffset timestamp, LogLevel logLevel, EventId eventId, Exception exception)
+        public LogInfo(string categoryName, DateTimeOffset timestamp, LogLevel logLevel, EventId eventId, Exception? exception)
         {
             EventId = eventId;
             CategoryName = categoryName;
@@ -52,7 +52,7 @@ namespace ZLogger
             WriteException(writer, Exception);
         }
 
-        static void WriteException(Utf8JsonWriter writer, Exception ex)
+        static void WriteException(Utf8JsonWriter writer, Exception? ex)
         {
             if (ex == null)
             {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/RollingFilestream.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/RollingFilestream.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -84,7 +84,7 @@ namespace ZLogger.Providers
                     sequenceNo = ExtractCurrentSequence(fileName) + 1;
                 }
 
-                string fn = null;
+                string? fn = null;
                 while (true)
                 {
                     try
@@ -131,7 +131,7 @@ namespace ZLogger.Providers
 
                     try
                     {
-                        fileName = fn;
+                        fileName = fn!;
                         currentTimestampPattern = ts;
                         if (File.Exists(fileName))
                         {
@@ -143,7 +143,7 @@ namespace ZLogger.Providers
                         }
 
                         var di = new FileInfo(fileName).Directory;
-                        if (!di.Exists)
+                        if (!di!.Exists)
                         {
                             di.Create();
                         }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Text;
@@ -17,7 +17,7 @@ namespace ZLogger.Providers
         {
         }
 
-        public ZLoggerConsoleLoggerProvider(bool consoleOutputEncodingToUtf8, string optionName, IOptionsMonitor<ZLoggerOptions> options)
+        public ZLoggerConsoleLoggerProvider(bool consoleOutputEncodingToUtf8, string? optionName, IOptionsMonitor<ZLoggerOptions> options)
         {
             if (consoleOutputEncodingToUtf8)
             {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerFileLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerFileLoggerProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
@@ -20,10 +20,10 @@ namespace ZLogger.Providers
         {
         }
 
-        public ZLoggerFileLoggerProvider(string filePath, string optionName, IOptionsMonitor<ZLoggerOptions> options)
+        public ZLoggerFileLoggerProvider(string filePath, string? optionName, IOptionsMonitor<ZLoggerOptions> options)
         {
             var di = new FileInfo(filePath).Directory;
-            if (!di.Exists)
+            if (!di!.Exists)
             {
                 di.Create();
             }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerLogProcessorLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerLogProcessorLoggerProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace ZLogger.Providers

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ namespace ZLogger.Providers
         {
         }
 
-        public ZLoggerRollingFileLoggerProvider(Func<DateTimeOffset, int, string> fileNameSelector, Func<DateTimeOffset, DateTimeOffset> timestampPattern, int rollSizeKB, string optionName, IOptionsMonitor<ZLoggerOptions> options)
+        public ZLoggerRollingFileLoggerProvider(Func<DateTimeOffset, int, string> fileNameSelector, Func<DateTimeOffset, DateTimeOffset> timestampPattern, int rollSizeKB, string? optionName, IOptionsMonitor<ZLoggerOptions> options)
         {
             var opt = options.Get(optionName ?? DefaultOptionName);
             var stream = new RollingFileStream(fileNameSelector, timestampPattern, rollSizeKB, opt);

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerStreamLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerStreamLoggerProvider.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.IO;
@@ -18,7 +18,7 @@ namespace ZLogger.Providers
         {
         }
 
-        public ZLoggerStreamLoggerProvider(Stream stream, string optionName, IOptionsMonitor<ZLoggerOptions> options)
+        public ZLoggerStreamLoggerProvider(Stream stream, string? optionName, IOptionsMonitor<ZLoggerOptions> options)
         {
             this.streamWriter = new AsyncStreamLineMessageWriter(stream, options.Get(optionName ?? DefaultOptionName));
         }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Shims/NullableAttributes.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Shims/NullableAttributes.cs
@@ -1,4 +1,4 @@
-#pragma warning disable MA0048 // File name must match type name
+﻿#pragma warning disable MA0048 // File name must match type name
 #define INTERNAL_NULLABLE_ATTRIBUTES
 #if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48|| UNITY_2018_3_OR_NEWER
 

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/StreamBufferWriter.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/StreamBufferWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -54,7 +54,7 @@ namespace ZLogger
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetForNewLine([NotNullWhen(true)]out byte[] rawBuffer, out int rawWritten)
+        public bool TryGetForNewLine([NotNullWhen(true)]out byte[]? rawBuffer, out int rawWritten)
         {
             if (buffer.Length - written > 2)
             {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/WindowsConsoleMode.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/WindowsConsoleMode.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace ZLogger

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Cysharp.Text;
 using Microsoft.Extensions.Logging;
 using ZLogger.Entries;
@@ -17,12 +17,12 @@ namespace ZLogger
             ZLog<T1>(logger, logLevel, eventId, null, format, arg1);
         }
 
-        public static void ZLog<T1>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1)
+        public static void ZLog<T1>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, logLevel, default, exception, format, arg1);
         }
 
-        public static void ZLog<T1>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLog<T1>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1>(null, format, arg1), exception, (state, ex) =>
             {
@@ -40,12 +40,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, logLevel, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogWithPayload<TPayload, T1>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogWithPayload<TPayload, T1>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, logLevel, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogWithPayload<TPayload, T1>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogWithPayload<TPayload, T1>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1>(payload, format, arg1), exception, (state, ex) =>
             {
@@ -63,12 +63,12 @@ namespace ZLogger
             ZLog<T1>(logger, LogLevel.Trace, eventId, null, format, arg1);
         }
 
-        public static void ZLogTrace<T1>(this ILogger logger, Exception exception, string format, T1 arg1)
+        public static void ZLogTrace<T1>(this ILogger logger, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Trace, default, exception, format, arg1);
         }
 
-        public static void ZLogTrace<T1>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLogTrace<T1>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Trace, eventId, exception, format, arg1);
         }
@@ -83,12 +83,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Trace, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogTraceWithPayload<TPayload, T1>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Trace, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogTraceWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1);
         }
@@ -103,12 +103,12 @@ namespace ZLogger
             ZLog<T1>(logger, LogLevel.Debug, eventId, null, format, arg1);
         }
 
-        public static void ZLogDebug<T1>(this ILogger logger, Exception exception, string format, T1 arg1)
+        public static void ZLogDebug<T1>(this ILogger logger, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Debug, default, exception, format, arg1);
         }
 
-        public static void ZLogDebug<T1>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLogDebug<T1>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Debug, eventId, exception, format, arg1);
         }
@@ -123,12 +123,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Debug, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogDebugWithPayload<TPayload, T1>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Debug, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogDebugWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1);
         }
@@ -143,12 +143,12 @@ namespace ZLogger
             ZLog<T1>(logger, LogLevel.Information, eventId, null, format, arg1);
         }
 
-        public static void ZLogInformation<T1>(this ILogger logger, Exception exception, string format, T1 arg1)
+        public static void ZLogInformation<T1>(this ILogger logger, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Information, default, exception, format, arg1);
         }
 
-        public static void ZLogInformation<T1>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLogInformation<T1>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Information, eventId, exception, format, arg1);
         }
@@ -163,12 +163,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Information, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogInformationWithPayload<TPayload, T1>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Information, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogInformationWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Information, eventId, exception, payload, format, arg1);
         }
@@ -183,12 +183,12 @@ namespace ZLogger
             ZLog<T1>(logger, LogLevel.Warning, eventId, null, format, arg1);
         }
 
-        public static void ZLogWarning<T1>(this ILogger logger, Exception exception, string format, T1 arg1)
+        public static void ZLogWarning<T1>(this ILogger logger, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Warning, default, exception, format, arg1);
         }
 
-        public static void ZLogWarning<T1>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLogWarning<T1>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Warning, eventId, exception, format, arg1);
         }
@@ -203,12 +203,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Warning, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogWarningWithPayload<TPayload, T1>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Warning, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogWarningWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1);
         }
@@ -223,12 +223,12 @@ namespace ZLogger
             ZLog<T1>(logger, LogLevel.Error, eventId, null, format, arg1);
         }
 
-        public static void ZLogError<T1>(this ILogger logger, Exception exception, string format, T1 arg1)
+        public static void ZLogError<T1>(this ILogger logger, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Error, default, exception, format, arg1);
         }
 
-        public static void ZLogError<T1>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLogError<T1>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Error, eventId, exception, format, arg1);
         }
@@ -243,12 +243,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Error, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogErrorWithPayload<TPayload, T1>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Error, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogErrorWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Error, eventId, exception, payload, format, arg1);
         }
@@ -263,12 +263,12 @@ namespace ZLogger
             ZLog<T1>(logger, LogLevel.Critical, eventId, null, format, arg1);
         }
 
-        public static void ZLogCritical<T1>(this ILogger logger, Exception exception, string format, T1 arg1)
+        public static void ZLogCritical<T1>(this ILogger logger, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Critical, default, exception, format, arg1);
         }
 
-        public static void ZLogCritical<T1>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1)
+        public static void ZLogCritical<T1>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1)
         {
             ZLog<T1>(logger, LogLevel.Critical, eventId, exception, format, arg1);
         }
@@ -283,12 +283,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Critical, eventId, null, payload, format, arg1);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogCriticalWithPayload<TPayload, T1>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Critical, default, exception, payload, format, arg1);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1)
+        public static void ZLogCriticalWithPayload<TPayload, T1>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1)
         {
             ZLogWithPayload<TPayload, T1>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1);
         }
@@ -304,12 +304,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, logLevel, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLog<T1, T2>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLog<T1, T2>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, logLevel, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLog<T1, T2>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLog<T1, T2>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2>(null, format, arg1, arg2), exception, (state, ex) =>
             {
@@ -327,12 +327,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, logLevel, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogWithPayload<TPayload, T1, T2>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, logLevel, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogWithPayload<TPayload, T1, T2>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2>(payload, format, arg1, arg2), exception, (state, ex) =>
             {
@@ -350,12 +350,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLogTrace<T1, T2>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogTrace<T1, T2>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Trace, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLogTrace<T1, T2>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogTrace<T1, T2>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2);
         }
@@ -370,12 +370,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2);
         }
@@ -390,12 +390,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLogDebug<T1, T2>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogDebug<T1, T2>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Debug, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLogDebug<T1, T2>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogDebug<T1, T2>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2);
         }
@@ -410,12 +410,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2);
         }
@@ -430,12 +430,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, LogLevel.Information, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLogInformation<T1, T2>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogInformation<T1, T2>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Information, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLogInformation<T1, T2>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogInformation<T1, T2>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2);
         }
@@ -450,12 +450,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2);
         }
@@ -470,12 +470,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLogWarning<T1, T2>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogWarning<T1, T2>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Warning, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLogWarning<T1, T2>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogWarning<T1, T2>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2);
         }
@@ -490,12 +490,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2);
         }
@@ -510,12 +510,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, LogLevel.Error, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLogError<T1, T2>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogError<T1, T2>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Error, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLogError<T1, T2>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogError<T1, T2>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2);
         }
@@ -530,12 +530,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2);
         }
@@ -550,12 +550,12 @@ namespace ZLogger
             ZLog<T1, T2>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2);
         }
 
-        public static void ZLogCritical<T1, T2>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogCritical<T1, T2>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Critical, default, exception, format, arg1, arg2);
         }
 
-        public static void ZLogCritical<T1, T2>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2)
+        public static void ZLogCritical<T1, T2>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2)
         {
             ZLog<T1, T2>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2);
         }
@@ -570,12 +570,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2)
         {
             ZLogWithPayload<TPayload, T1, T2>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2);
         }
@@ -591,12 +591,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, logLevel, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLog<T1, T2, T3>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLog<T1, T2, T3>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, logLevel, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLog<T1, T2, T3>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLog<T1, T2, T3>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3>(null, format, arg1, arg2, arg3), exception, (state, ex) =>
             {
@@ -614,12 +614,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3>(payload, format, arg1, arg2, arg3), exception, (state, ex) =>
             {
@@ -637,12 +637,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogTrace<T1, T2, T3>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogTrace<T1, T2, T3>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogTrace<T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogTrace<T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3);
         }
@@ -657,12 +657,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3);
         }
@@ -677,12 +677,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogDebug<T1, T2, T3>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogDebug<T1, T2, T3>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogDebug<T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogDebug<T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3);
         }
@@ -697,12 +697,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3);
         }
@@ -717,12 +717,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogInformation<T1, T2, T3>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogInformation<T1, T2, T3>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogInformation<T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogInformation<T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3);
         }
@@ -737,12 +737,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3);
         }
@@ -757,12 +757,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogWarning<T1, T2, T3>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogWarning<T1, T2, T3>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogWarning<T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogWarning<T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3);
         }
@@ -777,12 +777,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3);
         }
@@ -797,12 +797,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogError<T1, T2, T3>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogError<T1, T2, T3>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogError<T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogError<T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3);
         }
@@ -817,12 +817,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3);
         }
@@ -837,12 +837,12 @@ namespace ZLogger
             ZLog<T1, T2, T3>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogCritical<T1, T2, T3>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogCritical<T1, T2, T3>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogCritical<T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogCritical<T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLog<T1, T2, T3>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3);
         }
@@ -857,12 +857,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             ZLogWithPayload<TPayload, T1, T2, T3>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3);
         }
@@ -878,12 +878,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLog<T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLog<T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLog<T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLog<T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4>(null, format, arg1, arg2, arg3, arg4), exception, (state, ex) =>
             {
@@ -901,12 +901,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4>(payload, format, arg1, arg2, arg3, arg4), exception, (state, ex) =>
             {
@@ -924,12 +924,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogTrace<T1, T2, T3, T4>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogTrace<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4);
         }
@@ -944,12 +944,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4);
         }
@@ -964,12 +964,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogDebug<T1, T2, T3, T4>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogDebug<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4);
         }
@@ -984,12 +984,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4);
         }
@@ -1004,12 +1004,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogInformation<T1, T2, T3, T4>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogInformation<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4);
         }
@@ -1024,12 +1024,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4);
         }
@@ -1044,12 +1044,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogWarning<T1, T2, T3, T4>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogWarning<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4);
         }
@@ -1064,12 +1064,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4);
         }
@@ -1084,12 +1084,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogError<T1, T2, T3, T4>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogError<T1, T2, T3, T4>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogError<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogError<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4);
         }
@@ -1104,12 +1104,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4);
         }
@@ -1124,12 +1124,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogCritical<T1, T2, T3, T4>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogCritical<T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLog<T1, T2, T3, T4>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4);
         }
@@ -1144,12 +1144,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4);
         }
@@ -1165,12 +1165,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLog<T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLog<T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5>(null, format, arg1, arg2, arg3, arg4, arg5), exception, (state, ex) =>
             {
@@ -1188,12 +1188,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5>(payload, format, arg1, arg2, arg3, arg4, arg5), exception, (state, ex) =>
             {
@@ -1211,12 +1211,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogTrace<T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogTrace<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1231,12 +1231,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1251,12 +1251,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogDebug<T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogDebug<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1271,12 +1271,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1291,12 +1291,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogInformation<T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogInformation<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1311,12 +1311,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1331,12 +1331,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogWarning<T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogWarning<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1351,12 +1351,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1371,12 +1371,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogError<T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogError<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1391,12 +1391,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1411,12 +1411,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogCritical<T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogCritical<T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLog<T1, T2, T3, T4, T5>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1431,12 +1431,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5);
         }
@@ -1452,12 +1452,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLog<T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLog<T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6>(null, format, arg1, arg2, arg3, arg4, arg5, arg6), exception, (state, ex) =>
             {
@@ -1475,12 +1475,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6), exception, (state, ex) =>
             {
@@ -1498,12 +1498,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1518,12 +1518,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1538,12 +1538,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1558,12 +1558,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1578,12 +1578,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1598,12 +1598,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1618,12 +1618,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1638,12 +1638,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1658,12 +1658,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1678,12 +1678,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1698,12 +1698,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLog<T1, T2, T3, T4, T5, T6>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1718,12 +1718,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
@@ -1739,12 +1739,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7), exception, (state, ex) =>
             {
@@ -1762,12 +1762,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7), exception, (state, ex) =>
             {
@@ -1785,12 +1785,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1805,12 +1805,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1825,12 +1825,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1845,12 +1845,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1865,12 +1865,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1885,12 +1885,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1905,12 +1905,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1925,12 +1925,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1945,12 +1945,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1965,12 +1965,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -1985,12 +1985,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -2005,12 +2005,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
@@ -2026,12 +2026,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8), exception, (state, ex) =>
             {
@@ -2049,12 +2049,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8), exception, (state, ex) =>
             {
@@ -2072,12 +2072,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2092,12 +2092,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2112,12 +2112,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2132,12 +2132,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2152,12 +2152,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2172,12 +2172,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2192,12 +2192,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2212,12 +2212,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2232,12 +2232,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2252,12 +2252,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2272,12 +2272,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2292,12 +2292,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
@@ -2313,12 +2313,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9), exception, (state, ex) =>
             {
@@ -2336,12 +2336,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9), exception, (state, ex) =>
             {
@@ -2359,12 +2359,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2379,12 +2379,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2399,12 +2399,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2419,12 +2419,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2439,12 +2439,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2459,12 +2459,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2479,12 +2479,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2499,12 +2499,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2519,12 +2519,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2539,12 +2539,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2559,12 +2559,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2579,12 +2579,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
@@ -2600,12 +2600,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10), exception, (state, ex) =>
             {
@@ -2623,12 +2623,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10), exception, (state, ex) =>
             {
@@ -2646,12 +2646,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2666,12 +2666,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2686,12 +2686,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2706,12 +2706,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2726,12 +2726,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2746,12 +2746,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2766,12 +2766,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2786,12 +2786,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2806,12 +2806,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2826,12 +2826,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2846,12 +2846,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2866,12 +2866,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
@@ -2887,12 +2887,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11), exception, (state, ex) =>
             {
@@ -2910,12 +2910,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11), exception, (state, ex) =>
             {
@@ -2933,12 +2933,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -2953,12 +2953,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -2973,12 +2973,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -2993,12 +2993,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3013,12 +3013,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3033,12 +3033,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3053,12 +3053,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3073,12 +3073,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3093,12 +3093,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3113,12 +3113,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3133,12 +3133,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3153,12 +3153,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
@@ -3174,12 +3174,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12), exception, (state, ex) =>
             {
@@ -3197,12 +3197,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12), exception, (state, ex) =>
             {
@@ -3220,12 +3220,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3240,12 +3240,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3260,12 +3260,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3280,12 +3280,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3300,12 +3300,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3320,12 +3320,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3340,12 +3340,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3360,12 +3360,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3380,12 +3380,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3400,12 +3400,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3420,12 +3420,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3440,12 +3440,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
@@ -3461,12 +3461,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13), exception, (state, ex) =>
             {
@@ -3484,12 +3484,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13), exception, (state, ex) =>
             {
@@ -3507,12 +3507,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3527,12 +3527,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3547,12 +3547,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3567,12 +3567,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3587,12 +3587,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3607,12 +3607,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3627,12 +3627,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3647,12 +3647,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3667,12 +3667,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3687,12 +3687,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3707,12 +3707,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3727,12 +3727,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
@@ -3748,12 +3748,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, logLevel, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, logLevel, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             logger.Log(logLevel, eventId, new FormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14), exception, (state, ex) =>
             {
@@ -3771,12 +3771,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, logLevel, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, logLevel, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             logger.Log(logLevel, eventId, new FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14), exception, (state, ex) =>
             {
@@ -3794,12 +3794,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Trace, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Trace, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogTrace<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Trace, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3814,12 +3814,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Trace, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Trace, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogTraceWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Trace, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3834,12 +3834,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Debug, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Debug, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogDebug<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Debug, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3854,12 +3854,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Debug, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Debug, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogDebugWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Debug, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3874,12 +3874,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Information, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Information, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogInformation<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Information, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3894,12 +3894,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Information, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Information, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogInformationWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Information, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3914,12 +3914,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Warning, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Warning, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogWarning<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Warning, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3934,12 +3934,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Warning, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Warning, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogWarningWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Warning, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3954,12 +3954,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Error, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Error, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogError<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Error, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3974,12 +3974,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Error, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Error, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogErrorWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Error, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -3994,12 +3994,12 @@ namespace ZLogger
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Critical, eventId, null, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Critical, default, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogCritical<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLog<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Critical, eventId, exception, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -4014,12 +4014,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Critical, eventId, null, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Critical, default, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        public static void ZLogCriticalWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             ZLogWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(logger, LogLevel.Critical, eventId, exception, payload, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
@@ -4035,12 +4035,12 @@ namespace ZLogger
             ZLog(logger, logLevel, eventId, default(Exception), message);
         }
 
-        public static void ZLog(this ILogger logger, LogLevel logLevel, Exception exception, string message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, string message)
         {
             ZLog(logger, logLevel, default(EventId), exception, message);
         }
 
-        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string message)
         {
             logger.Log(logLevel, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4058,12 +4058,12 @@ namespace ZLogger
             ZLogWithPayload<TPayload>(logger, logLevel, eventId, null, payload, message);
         }
 
-        public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, Exception exception, TPayload payload, string message)
+        public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, Exception? exception, TPayload payload, string message)
         {
             ZLogWithPayload<TPayload>(logger, logLevel, default, exception, payload, message);
         }
 
-        public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogWithPayload<TPayload>(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(logLevel, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
@@ -4081,12 +4081,12 @@ namespace ZLogger
             ZLogTrace(logger, eventId, default(Exception), message);
         }
 
-        public static void ZLogTrace(this ILogger logger, Exception exception, string message)
+        public static void ZLogTrace(this ILogger logger, Exception? exception, string message)
         {
             ZLogTrace(logger, default(EventId), exception, message);
         }
 
-        public static void ZLogTrace(this ILogger logger, EventId eventId, Exception exception, string message)
+        public static void ZLogTrace(this ILogger logger, EventId eventId, Exception? exception, string message)
         {
             logger.Log(LogLevel.Trace, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4104,12 +4104,12 @@ namespace ZLogger
             ZLogTraceWithPayload<TPayload>(logger, eventId, null, payload, message);
         }
 
-        public static void ZLogTraceWithPayload<TPayload>(this ILogger logger, Exception exception, TPayload payload, string message)
+        public static void ZLogTraceWithPayload<TPayload>(this ILogger logger, Exception? exception, TPayload payload, string message)
         {
             ZLogTraceWithPayload<TPayload>(logger, default, exception, payload, message);
         }
 
-        public static void ZLogTraceWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogTraceWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(LogLevel.Trace, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
@@ -4127,12 +4127,12 @@ namespace ZLogger
             ZLogDebug(logger, eventId, default(Exception), message);
         }
 
-        public static void ZLogDebug(this ILogger logger, Exception exception, string message)
+        public static void ZLogDebug(this ILogger logger, Exception? exception, string message)
         {
             ZLogDebug(logger, default(EventId), exception, message);
         }
 
-        public static void ZLogDebug(this ILogger logger, EventId eventId, Exception exception, string message)
+        public static void ZLogDebug(this ILogger logger, EventId eventId, Exception? exception, string message)
         {
             logger.Log(LogLevel.Debug, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4150,12 +4150,12 @@ namespace ZLogger
             ZLogDebugWithPayload<TPayload>(logger, eventId, null, payload, message);
         }
 
-        public static void ZLogDebugWithPayload<TPayload>(this ILogger logger, Exception exception, TPayload payload, string message)
+        public static void ZLogDebugWithPayload<TPayload>(this ILogger logger, Exception? exception, TPayload payload, string message)
         {
             ZLogDebugWithPayload<TPayload>(logger, default, exception, payload, message);
         }
 
-        public static void ZLogDebugWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogDebugWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(LogLevel.Debug, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
@@ -4173,12 +4173,12 @@ namespace ZLogger
             ZLogInformation(logger, eventId, default(Exception), message);
         }
 
-        public static void ZLogInformation(this ILogger logger, Exception exception, string message)
+        public static void ZLogInformation(this ILogger logger, Exception? exception, string message)
         {
             ZLogInformation(logger, default(EventId), exception, message);
         }
 
-        public static void ZLogInformation(this ILogger logger, EventId eventId, Exception exception, string message)
+        public static void ZLogInformation(this ILogger logger, EventId eventId, Exception? exception, string message)
         {
             logger.Log(LogLevel.Information, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4196,12 +4196,12 @@ namespace ZLogger
             ZLogInformationWithPayload<TPayload>(logger, eventId, null, payload, message);
         }
 
-        public static void ZLogInformationWithPayload<TPayload>(this ILogger logger, Exception exception, TPayload payload, string message)
+        public static void ZLogInformationWithPayload<TPayload>(this ILogger logger, Exception? exception, TPayload payload, string message)
         {
             ZLogInformationWithPayload<TPayload>(logger, default, exception, payload, message);
         }
 
-        public static void ZLogInformationWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogInformationWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(LogLevel.Information, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
@@ -4219,12 +4219,12 @@ namespace ZLogger
             ZLogWarning(logger, eventId, default(Exception), message);
         }
 
-        public static void ZLogWarning(this ILogger logger, Exception exception, string message)
+        public static void ZLogWarning(this ILogger logger, Exception? exception, string message)
         {
             ZLogWarning(logger, default(EventId), exception, message);
         }
 
-        public static void ZLogWarning(this ILogger logger, EventId eventId, Exception exception, string message)
+        public static void ZLogWarning(this ILogger logger, EventId eventId, Exception? exception, string message)
         {
             logger.Log(LogLevel.Warning, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4242,12 +4242,12 @@ namespace ZLogger
             ZLogWarningWithPayload<TPayload>(logger, eventId, null, payload, message);
         }
 
-        public static void ZLogWarningWithPayload<TPayload>(this ILogger logger, Exception exception, TPayload payload, string message)
+        public static void ZLogWarningWithPayload<TPayload>(this ILogger logger, Exception? exception, TPayload payload, string message)
         {
             ZLogWarningWithPayload<TPayload>(logger, default, exception, payload, message);
         }
 
-        public static void ZLogWarningWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogWarningWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(LogLevel.Warning, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
@@ -4265,12 +4265,12 @@ namespace ZLogger
             ZLogError(logger, eventId, default(Exception), message);
         }
 
-        public static void ZLogError(this ILogger logger, Exception exception, string message)
+        public static void ZLogError(this ILogger logger, Exception? exception, string message)
         {
             ZLogError(logger, default(EventId), exception, message);
         }
 
-        public static void ZLogError(this ILogger logger, EventId eventId, Exception exception, string message)
+        public static void ZLogError(this ILogger logger, EventId eventId, Exception? exception, string message)
         {
             logger.Log(LogLevel.Error, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4288,12 +4288,12 @@ namespace ZLogger
             ZLogErrorWithPayload<TPayload>(logger, eventId, null, payload, message);
         }
 
-        public static void ZLogErrorWithPayload<TPayload>(this ILogger logger, Exception exception, TPayload payload, string message)
+        public static void ZLogErrorWithPayload<TPayload>(this ILogger logger, Exception? exception, TPayload payload, string message)
         {
             ZLogErrorWithPayload<TPayload>(logger, default, exception, payload, message);
         }
 
-        public static void ZLogErrorWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogErrorWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(LogLevel.Error, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {
@@ -4311,12 +4311,12 @@ namespace ZLogger
             ZLogCritical(logger, eventId, default(Exception), message);
         }
 
-        public static void ZLogCritical(this ILogger logger, Exception exception, string message)
+        public static void ZLogCritical(this ILogger logger, Exception? exception, string message)
         {
             ZLogCritical(logger, default(EventId), exception, message);
         }
 
-        public static void ZLogCritical(this ILogger logger, EventId eventId, Exception exception, string message)
+        public static void ZLogCritical(this ILogger logger, EventId eventId, Exception? exception, string message)
         {
             logger.Log(LogLevel.Critical, eventId, new MessageLogState<object>(null, message), exception, (state, ex) =>
             {
@@ -4334,12 +4334,12 @@ namespace ZLogger
             ZLogCriticalWithPayload<TPayload>(logger, eventId, null, payload, message);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload>(this ILogger logger, Exception exception, TPayload payload, string message)
+        public static void ZLogCriticalWithPayload<TPayload>(this ILogger logger, Exception? exception, TPayload payload, string message)
         {
             ZLogCriticalWithPayload<TPayload>(logger, default, exception, payload, message);
         }
 
-        public static void ZLogCriticalWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception exception, TPayload payload, string message)
+        public static void ZLogCriticalWithPayload<TPayload>(this ILogger logger, EventId eventId, Exception? exception, TPayload payload, string message)
         {
             logger.Log(LogLevel.Critical, eventId, new MessageLogState<TPayload>(payload, message), exception, (state, ex) =>
             {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerLoggingBuilderExtensions.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerLoggingBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerMessage.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/ZLoggerMessage.cs
@@ -1,4 +1,4 @@
-using Cysharp.Text;
+﻿using Cysharp.Text;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -9,19 +9,19 @@ namespace ZLogger
 {
     public static class ZLoggerMessage
     {
-        public static Action<ILogger, Exception> Define(LogLevel logLevel, EventId eventId, string message)
+        public static Action<ILogger, Exception?> Define(LogLevel logLevel, EventId eventId, string message)
         {
-            return (ILogger logger, Exception ex) =>
+            return (ILogger logger, Exception? ex) =>
             {
                 logger.ZLog(logLevel, eventId, ex, message);
             };
         }
 
-        public static Action<ILogger, T1, Exception> Define<T1>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1>(format);
 
-            return (ILogger logger, T1 arg1, Exception ex) =>
+            return (ILogger logger, T1 arg1, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1>(null, prepared, arg1), ex, (state, _) =>
                 {
@@ -30,11 +30,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, Exception> Define<T1, T2>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2>(null, prepared, arg1, arg2), ex, (state, _) =>
                 {
@@ -43,11 +43,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, Exception> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3>(null, prepared, arg1, arg2, arg3), ex, (state, _) =>
                 {
@@ -56,11 +56,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, Exception> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4>(null, prepared, arg1, arg2, arg3, arg4), ex, (state, _) =>
                 {
@@ -69,11 +69,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, Exception> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5>(null, prepared, arg1, arg2, arg3, arg4, arg5), ex, (state, _) =>
                 {
@@ -82,11 +82,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, Exception> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6), ex, (state, _) =>
                 {
@@ -95,11 +95,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, Exception> Define<T1, T2, T3, T4, T5, T6, T7>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, Exception?> Define<T1, T2, T3, T4, T5, T6, T7>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7), ex, (state, _) =>
                 {
@@ -108,11 +108,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8), ex, (state, _) =>
                 {
@@ -121,11 +121,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9), ex, (state, _) =>
                 {
@@ -134,11 +134,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10), ex, (state, _) =>
                 {
@@ -147,11 +147,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11), ex, (state, _) =>
                 {
@@ -160,11 +160,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12), ex, (state, _) =>
                 {
@@ -173,11 +173,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13), ex, (state, _) =>
                 {
@@ -186,11 +186,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Exception?> Define<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(format);
 
-            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, Exception ex) =>
+            return (ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<object, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(null, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14), ex, (state, _) =>
                 {
@@ -200,11 +200,11 @@ namespace ZLogger
         }
 
 
-        public static Action<ILogger, TPayload, T1, Exception> DefineWithPayload<TPayload, T1>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, Exception?> DefineWithPayload<TPayload, T1>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1>(payload, prepared, arg1), ex, (state, _) =>
                 {
@@ -213,11 +213,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, Exception> DefineWithPayload<TPayload, T1, T2>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, Exception?> DefineWithPayload<TPayload, T1, T2>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2>(payload, prepared, arg1, arg2), ex, (state, _) =>
                 {
@@ -226,11 +226,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, Exception> DefineWithPayload<TPayload, T1, T2, T3>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, Exception?> DefineWithPayload<TPayload, T1, T2, T3>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3>(payload, prepared, arg1, arg2, arg3), ex, (state, _) =>
                 {
@@ -239,11 +239,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4>(payload, prepared, arg1, arg2, arg3, arg4), ex, (state, _) =>
                 {
@@ -252,11 +252,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5>(payload, prepared, arg1, arg2, arg3, arg4, arg5), ex, (state, _) =>
                 {
@@ -265,11 +265,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6), ex, (state, _) =>
                 {
@@ -278,11 +278,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7), ex, (state, _) =>
                 {
@@ -291,11 +291,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8), ex, (state, _) =>
                 {
@@ -304,11 +304,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9), ex, (state, _) =>
                 {
@@ -317,11 +317,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10), ex, (state, _) =>
                 {
@@ -330,11 +330,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11), ex, (state, _) =>
                 {
@@ -343,11 +343,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12), ex, (state, _) =>
                 {
@@ -356,11 +356,11 @@ namespace ZLogger
             };
         }
 
-        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Exception> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(LogLevel logLevel, EventId eventId, string format)
+        public static Action<ILogger, TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Exception?> DefineWithPayload<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(LogLevel logLevel, EventId eventId, string format)
         {
             var prepared = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(format);
 
-            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, Exception ex) =>
+            return (ILogger logger, TPayload payload, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, Exception? ex) =>
             {
                 logger.Log(logLevel, eventId, new PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(payload, prepared, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13), ex, (state, _) =>
                 {

--- a/src/ZLogger/Entries/FormatLogEntry.cs
+++ b/src/ZLogger/Entries/FormatLogEntry.cs
@@ -98,9 +98,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -175,9 +173,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -303,9 +299,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -380,9 +374,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -513,8 +505,7 @@ namespace ZLogger.Entries
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
 
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -589,9 +580,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -725,9 +714,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -802,9 +789,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -942,9 +927,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1019,9 +1002,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1163,9 +1144,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1240,9 +1219,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1388,9 +1365,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1465,9 +1440,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1617,9 +1590,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1694,9 +1665,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1850,9 +1819,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -1927,9 +1894,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2087,9 +2052,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2164,9 +2127,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2328,9 +2289,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2405,9 +2364,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2573,9 +2530,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11, state.Arg12);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2650,9 +2605,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2822,9 +2775,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11, state.Arg12, state.Arg13);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -2899,9 +2850,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -3075,9 +3024,7 @@ namespace ZLogger.Entries
                     sb.AppendFormat(state.Format, state.Arg1, state.Arg2, state.Arg3, state.Arg4, state.Arg5, state.Arg6, state.Arg7, state.Arg8, state.Arg9, state.Arg10, state.Arg11, state.Arg12, state.Arg13, state.Arg14);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {
@@ -3152,9 +3099,7 @@ namespace ZLogger.Entries
                 {
                     sb.Dispose();
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {

--- a/src/ZLogger/Entries/MessageLogEntry.cs
+++ b/src/ZLogger/Entries/MessageLogEntry.cs
@@ -72,9 +72,7 @@ namespace ZLogger.Entries
                     sb.Append(state.Message);
                     jsonWriter.WriteString(options.MessagePropertyName, sb.AsSpan());
                 }
-
-                jsonWriter.WritePropertyName(options.PayloadPropertyName);
-                JsonSerializer.Serialize(jsonWriter, state.Payload, options.JsonSerializerOptions);
+                options.PayloadLoggingFormatter.Invoke(jsonWriter, state.Payload, options.JsonSerializerOptions, options);
             }
             else
             {

--- a/src/ZLogger/ZLogger.csproj
+++ b/src/ZLogger/ZLogger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>8.0</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -77,16 +77,16 @@
     </ItemGroup>
 
     <!-- Copy files for Unity -->
-    <PropertyGroup>
-        <DestinationRoot>$(MSBuildProjectDirectory)\..\ZLogger.Unity\Assets\Scripts\ZLogger\</DestinationRoot>
-    </PropertyGroup>
-    <ItemGroup>
-        <TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />
-    </ItemGroup>
-    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-        <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
+<!--    <PropertyGroup>-->
+<!--        <DestinationRoot>$(MSBuildProjectDirectory)\..\ZLogger.Unity\Assets\Scripts\ZLogger\</DestinationRoot>-->
+<!--    </PropertyGroup>-->
+<!--    <ItemGroup>-->
+<!--        <TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />-->
+<!--    </ItemGroup>-->
+<!--    <Target Name="PostBuild" AfterTargets="PostBuildEvent">-->
+<!--        <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />-->
 
-        <!-- After copy, remove nullable reference -->
-        <Exec Command="dotnet run --no-build -c $(ConfigurationName) --project $(MSBuildProjectDirectory)\..\..\tools\CommandTools\CommandTools.csproj -- remove-nullable-reference $(DestinationRoot)" />
-    </Target>
+<!--        &lt;!&ndash; After copy, remove nullable reference &ndash;&gt;-->
+<!--        <Exec Command="dotnet run &#45;&#45;no-build -c $(ConfigurationName) &#45;&#45;project $(MSBuildProjectDirectory)\..\..\tools\CommandTools\CommandTools.csproj &#45;&#45; remove-nullable-reference $(DestinationRoot)" />-->
+<!--    </Target>-->
 </Project>

--- a/tests/ZLogger.Tests/ZLogger.Tests.csproj
+++ b/tests/ZLogger.Tests/ZLogger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tools/CommandTools/CommandTools.csproj
+++ b/tools/CommandTools/CommandTools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
output of benchmark:
|           Method |       Mean | Error |  Gen 0 |  Gen 1 | Allocated |
|----------------- |-----------:|------:|-------:|-------:|----------:|
|         SeriFile | 2,888.7 ns |    NA | 0.4272 |      - |     896 B |
|            ZFile |   186.9 ns |    NA | 0.0122 | 0.0043 |      77 B |
| ZFileWithPayload |   251.5 ns |    NA | 0.0205 | 0.0081 |     129 B |