### PR TITLE
Support `ILogger.BeginScope`

### DIFF
--- a/sandbox/Benchmark/Benchmarks/WriteToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteToFile.cs
@@ -65,7 +65,7 @@ namespace Benchmark.Benchmarks
             Arg1 = arg1;
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
             return null;
         }

--- a/sandbox/Benchmark/Benchmarks/WriteToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteToFile.cs
@@ -31,8 +31,6 @@ namespace Benchmark.Benchmarks
             var serviceProvider = serviceCollection.BuildServiceProvider();
             ZLogger = serviceProvider.GetService<ILoggerProvider>();
             ZLoggerLogger = ZLogger.CreateLogger("temp");
-
-
         }
 
         [Benchmark]

--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -70,7 +70,10 @@ namespace ZLogger.MessagePack
         {
             var messagePackWriter = new MessagePackWriter(writer);
 
-            messagePackWriter.WriteMapHeader(6 + (entry.LogInfo.Exception != null ? 1 : 0) + (payload != null ? 1 : 0));
+            messagePackWriter.WriteMapHeader(6 + 
+                                             (entry.LogInfo.Exception != null ? 1 : 0) + 
+                                             (payload != null ? 1 : 0) +
+                                             (entry.ScopeState?.Properties.Count ?? 0));
 
             messagePackWriter.WriteRaw(CategoryNameKey);
             messagePackWriter.Write(entry.LogInfo.CategoryName);
@@ -101,6 +104,27 @@ namespace ZLogger.MessagePack
                 messagePackWriter.Write(PayloadPropertyName);
                 MessagePackSerializerOptions.Resolver.GetFormatterWithVerify<TPayload>()
                     .Serialize(ref messagePackWriter, payload, MessagePackSerializerOptions);
+            }
+            if (entry.ScopeState is { IsEmpty: false } scopeState)
+            {
+                for (var i = 0; i < scopeState.Properties.Count; i++)
+                {
+                    var x = scopeState.Properties[i];
+                    // If `BeginScope(format, arg1, arg2)` style is used, the first argument `format` string is passed with this name
+                    if (x.Key == "{OriginalFormat}")
+                        continue;
+                    
+                    messagePackWriter.Write(x.Key);
+                    if (x.Value is { } value)
+                    {
+                        MessagePackSerializer.Serialize(value.GetType(), ref messagePackWriter, value,
+                            MessagePackSerializerOptions);
+                    }
+                    else
+                    {
+                        messagePackWriter.WriteNil();
+                    }
+                }
             }
             messagePackWriter.Flush();
         }

--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Buffers;
 using MessagePack;
 using Microsoft.Extensions.Logging;
@@ -73,7 +74,7 @@ namespace ZLogger.MessagePack
             messagePackWriter.WriteMapHeader(6 + 
                                              (entry.LogInfo.Exception != null ? 1 : 0) + 
                                              (payload != null ? 1 : 0) +
-                                             (entry.ScopeState?.Properties.Count ?? 0));
+                                             (entry.ScopeState?.Properties.Count(x => x.Key != "{OriginalFormat}") ?? 0));
 
             messagePackWriter.WriteRaw(CategoryNameKey);
             messagePackWriter.Write(entry.LogInfo.CategoryName);

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/FormatLogEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/FormatLogEntry.cs
@@ -12,7 +12,7 @@ namespace ZLogger.Entries
 {
     public struct FormatLogState<TPayload, T1> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -25,20 +25,20 @@ namespace ZLogger.Entries
             Arg1 = arg1;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1> Format;
@@ -51,30 +51,27 @@ namespace ZLogger.Entries
             Arg1 = arg1;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1>> cache = new();
 
         FormatLogState<TPayload, T1> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1> state)
+        public static FormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -83,6 +80,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -99,6 +97,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -118,17 +118,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1>> cache = new();
 
         PreparedFormatLogState<TPayload, T1> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1> state)
+        public static PreparedFormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -137,6 +134,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -158,6 +156,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -177,7 +177,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -192,20 +192,20 @@ namespace ZLogger.Entries
             Arg2 = arg2;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2> Format;
@@ -220,30 +220,27 @@ namespace ZLogger.Entries
             Arg2 = arg2;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2>> cache = new();
 
         FormatLogState<TPayload, T1, T2> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2> state)
+        public static FormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -252,6 +249,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -268,6 +266,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -287,17 +287,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -306,6 +303,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -327,6 +325,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -346,7 +346,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -363,20 +363,20 @@ namespace ZLogger.Entries
             Arg3 = arg3;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3> Format;
@@ -393,30 +393,27 @@ namespace ZLogger.Entries
             Arg3 = arg3;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -425,6 +422,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -441,6 +439,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -460,17 +460,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -479,6 +476,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -500,6 +498,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -519,7 +519,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -538,20 +538,20 @@ namespace ZLogger.Entries
             Arg4 = arg4;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4> Format;
@@ -570,30 +570,27 @@ namespace ZLogger.Entries
             Arg4 = arg4;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -602,6 +599,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -618,6 +616,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -637,17 +637,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -656,6 +653,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -677,6 +675,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -696,7 +696,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -717,20 +717,20 @@ namespace ZLogger.Entries
             Arg5 = arg5;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5> Format;
@@ -751,30 +751,27 @@ namespace ZLogger.Entries
             Arg5 = arg5;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -783,6 +780,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -799,6 +797,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -818,17 +818,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -837,6 +834,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -858,6 +856,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -877,7 +877,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -900,20 +900,20 @@ namespace ZLogger.Entries
             Arg6 = arg6;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6> Format;
@@ -936,30 +936,27 @@ namespace ZLogger.Entries
             Arg6 = arg6;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -968,6 +965,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -984,6 +982,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1003,17 +1003,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1022,6 +1019,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1043,6 +1041,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1062,7 +1062,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1087,20 +1087,20 @@ namespace ZLogger.Entries
             Arg7 = arg7;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7> Format;
@@ -1125,30 +1125,27 @@ namespace ZLogger.Entries
             Arg7 = arg7;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1157,6 +1154,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1173,6 +1171,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1192,17 +1192,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1211,6 +1208,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1232,6 +1230,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1251,7 +1251,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1278,20 +1278,20 @@ namespace ZLogger.Entries
             Arg8 = arg8;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8> Format;
@@ -1318,30 +1318,27 @@ namespace ZLogger.Entries
             Arg8 = arg8;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1350,6 +1347,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1366,6 +1364,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1385,17 +1385,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1404,6 +1401,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1425,6 +1423,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1444,7 +1444,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1473,20 +1473,20 @@ namespace ZLogger.Entries
             Arg9 = arg9;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9> Format;
@@ -1515,30 +1515,27 @@ namespace ZLogger.Entries
             Arg9 = arg9;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1547,6 +1544,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1563,6 +1561,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1582,17 +1582,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1601,6 +1598,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1622,6 +1620,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1641,7 +1641,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1672,20 +1672,20 @@ namespace ZLogger.Entries
             Arg10 = arg10;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Format;
@@ -1716,30 +1716,27 @@ namespace ZLogger.Entries
             Arg10 = arg10;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1748,6 +1745,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1764,6 +1762,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1783,17 +1783,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1802,6 +1799,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1823,6 +1821,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1842,7 +1842,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1875,20 +1875,20 @@ namespace ZLogger.Entries
             Arg11 = arg11;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Format;
@@ -1921,30 +1921,27 @@ namespace ZLogger.Entries
             Arg11 = arg11;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1953,6 +1950,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1969,6 +1967,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1988,17 +1988,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2007,6 +2004,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2028,6 +2026,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2047,7 +2047,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -2082,20 +2082,20 @@ namespace ZLogger.Entries
             Arg12 = arg12;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Format;
@@ -2130,30 +2130,27 @@ namespace ZLogger.Entries
             Arg12 = arg12;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2162,6 +2159,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2178,6 +2176,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2197,17 +2197,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2216,6 +2213,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2237,6 +2235,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2256,7 +2256,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -2293,20 +2293,20 @@ namespace ZLogger.Entries
             Arg13 = arg13;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Format;
@@ -2343,30 +2343,27 @@ namespace ZLogger.Entries
             Arg13 = arg13;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2375,6 +2372,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2391,6 +2389,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2410,17 +2410,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2429,6 +2426,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2450,6 +2448,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2469,7 +2469,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -2508,20 +2508,20 @@ namespace ZLogger.Entries
             Arg14 = arg14;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Format;
@@ -2560,30 +2560,27 @@ namespace ZLogger.Entries
             Arg14 = arg14;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2592,6 +2589,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2608,6 +2606,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2627,17 +2627,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2646,6 +2643,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2667,6 +2665,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/StringFormatterEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Entries/StringFormatterEntry.cs
@@ -7,8 +7,7 @@ namespace ZLogger.Entries
 {
     public class StringFormatterEntry<TState> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<StringFormatterEntry<TState>> cache = new ConcurrentQueue<StringFormatterEntry<TState>>();
-        static readonly byte[] newLineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+        static readonly ConcurrentQueue<StringFormatterEntry<TState>> cache = new();
 
 #pragma warning disable CS8618
         TState state;
@@ -16,10 +15,11 @@ namespace ZLogger.Entries
         Func<TState, Exception?, string> formatter;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
 #pragma warning restore CS8618
 
-        public static StringFormatterEntry<TState> Create(LogInfo info, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        public static StringFormatterEntry<TState> Create(LogInfo info, TState state, LogScopeState? scopeState, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             if (!cache.TryDequeue(out var entry))
             {
@@ -30,6 +30,7 @@ namespace ZLogger.Entries
             entry.state = state;
             entry.exception = exception;
             entry.formatter = formatter;
+            entry.ScopeState = scopeState;
 
             return entry;
         }
@@ -67,6 +68,9 @@ namespace ZLogger.Entries
             this.LogInfo = default!;
             this.exception = default!;
             this.formatter = default!;
+            
+            ScopeState?.Return();
+            ScopeState = null;
         }
     }
 }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
@@ -29,7 +29,7 @@ namespace ZLogger.Formatters
                 ExceptionFormatter(writer, ex);
             }
         }
-
+        
         static void DefaultExceptionLoggingFormatter(IBufferWriter<byte> writer, Exception exception)
         {
             // \n + exception

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerEntry.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerEntry.cs
@@ -7,6 +7,7 @@ namespace ZLogger
     public interface IZLoggerEntry
     {
         LogInfo LogInfo { get; }
+        LogScopeState? ScopeState { get; }
         void FormatUtf8(IBufferWriter<byte> writer, IZLoggerFormatter formatter);
         void SwitchCasePayload<TPayload>(Action<IZLoggerEntry, TPayload, object?> payloadCallback, object? state);
         object? GetPayload();

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerState.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/IZLoggerState.cs
@@ -2,6 +2,6 @@ namespace ZLogger
 {
     public interface IZLoggerState
     {
-        IZLoggerEntry CreateLogEntry(LogInfo logInfo);
+        IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState);
     }
 }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/LogScopeState.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/LogScopeState.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace ZLogger
+{
+    public class LogScopeState
+    {
+        const string DefaultScopeKeyName = "Scope";
+        static readonly ConcurrentQueue<LogScopeState> cache = new();        
+        
+        public bool IsEmpty => properties.Count <= 0;
+
+        public IReadOnlyList<KeyValuePair<string, object?>> Properties => properties;
+
+        readonly List<KeyValuePair<string, object?>> properties = new();
+
+        public static LogScopeState Create(IExternalScopeProvider scopeProvider)
+        {
+            if (!cache.TryDequeue(out var result))
+            {
+                result = new LogScopeState();
+            }
+            result.Snapshot(scopeProvider);
+            return result;
+        }
+        
+        public void Return()
+        {
+            Clear();
+            cache.Enqueue(this);
+        }
+
+        void Clear()
+        {
+            properties.Clear();
+        }
+        
+        void Snapshot(IExternalScopeProvider scopeProvider)
+        {
+            Clear();
+            scopeProvider.ForEachScope(static (state, props) =>
+            {
+                switch (state)
+                {
+                    // For example, using the `BeginScope(format, arg1, arg2, ...)` style, state is `FormattedLogValues : IEnumerable<KeyValuePair<string, object>>`.
+                    case IEnumerable<KeyValuePair<string, object?>> enumerable:
+                        props.AddRange(enumerable);
+                        break;
+                    case KeyValuePair<string, object?> prop:
+                        props.Add(prop);
+                        break;
+                    default:
+                        props.Add(new KeyValuePair<string, object?>(DefaultScopeKeyName, state));
+                        break;
+                }
+            }, properties);
+        }
+    }
+}

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
@@ -6,11 +6,12 @@ using System.Text;
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerConsole")]
-    public class ZLoggerConsoleLoggerProvider : ILoggerProvider
+    public class ZLoggerConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         internal const string DefaultOptionName = "ZLoggerConsole.Default";
 
-        AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamLineMessageWriter streamWriter;
+        IExternalScopeProvider? scopeProvider; 
 
         public ZLoggerConsoleLoggerProvider(IOptionsMonitor<ZLoggerOptions> options)
             : this(true, null, options)
@@ -36,12 +37,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, streamWriter);
+            return new AsyncProcessZLogger(categoryName, streamWriter)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             streamWriter.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerLogProcessorLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerLogProcessorLoggerProvider.cs
@@ -1,12 +1,12 @@
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerLogProcessor")]
-    public class ZLoggerLogProcessorLoggerProvider : ILoggerProvider
+    public class ZLoggerLogProcessorLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
-        IAsyncLogProcessor processor;
+        readonly IAsyncLogProcessor processor;
+        IExternalScopeProvider? scopeProvider;
 
         public ZLoggerLogProcessorLoggerProvider(IAsyncLogProcessor processor)
         {
@@ -15,12 +15,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, processor);
+            return new AsyncProcessZLogger(categoryName, processor)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             processor.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
@@ -1,10 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading;
 
 namespace ZLogger.Providers
 {

--- a/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
+++ b/src/ZLogger.Unity/Assets/Scripts/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
@@ -5,11 +5,12 @@ using System;
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerRollingFile")]
-    public class ZLoggerRollingFileLoggerProvider : ILoggerProvider
+    public class ZLoggerRollingFileLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         internal const string DefaultOptionName = "ZLoggerRollingFile.Default";
 
-        AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamLineMessageWriter streamWriter;
+        IExternalScopeProvider? scopeProvider;
 
         public ZLoggerRollingFileLoggerProvider(Func<DateTimeOffset, int, string> fileNameSelector, Func<DateTimeOffset, DateTimeOffset> timestampPattern, int rollSizeKB, IOptionsMonitor<ZLoggerOptions> options)
             : this(fileNameSelector, timestampPattern, rollSizeKB, DefaultOptionName, options)
@@ -25,12 +26,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, streamWriter);
+            return new AsyncProcessZLogger(categoryName, streamWriter)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             streamWriter.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger/AsyncProcessZLogger.cs
+++ b/src/ZLogger/AsyncProcessZLogger.cs
@@ -1,14 +1,13 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
-using System.Linq.Expressions;
 using ZLogger.Entries;
 
 namespace ZLogger
 {
     public class AsyncProcessZLogger : ILogger
     {
-        readonly Func<string, Exception?, string> ReturnStringStateFormatter = (state, _) => state;
-
+        public IExternalScopeProvider? ScopeProvider { get; set; } 
+        
         readonly string categoryName;
         readonly IAsyncLogProcessor logProcessor;
 
@@ -20,45 +19,21 @@ namespace ZLogger
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            var factory = CreateLogEntry<TState>.factory;
-            if (factory != null)
-            {
-                var info = new LogInfo(categoryName, DateTimeOffset.UtcNow, logLevel, eventId, exception);
-                var entry = factory.Invoke(state, info);
-                logProcessor.Post(entry);
-            }
-            else
-            {
-                var info = new LogInfo(categoryName, DateTimeOffset.UtcNow, logLevel, eventId, exception);
-                if (StateTypeDetector<TState>.IsInternalFormattedLogValues || state == null)
-                {
-                    // null state automatically converted to FormattedLogValues struct.
-                    logProcessor.Post(StringFormatterEntry<TState>.Create(info, state, exception, formatter));
-                }
-                else
-                {
-                    // sometimes state has context(like HttpContext), it require to format in scope.
-                    var message = formatter(state, exception);
-                    logProcessor.Post(StringFormatterEntry<string>.Create(info, message, exception, ReturnStringStateFormatter));
-                }
-            }
-        }
+            var info = new LogInfo(categoryName, DateTimeOffset.UtcNow, logLevel, eventId, exception);
+            
+            var scopeState = ScopeProvider != null
+                ? LogScopeState.Create(ScopeProvider)
+                : null;
+            
+            var entry = CreateLogEntry<TState>.factory?.Invoke(state, info, scopeState) ?? 
+                        StringFormatterEntry<TState>.Create(info, state, scopeState, exception, formatter);
 
-
-        static class StateTypeDetector<TState>
-        {
-            public static readonly bool IsInternalFormattedLogValues;
-
-            static StateTypeDetector()
-            {
-                IsInternalFormattedLogValues = typeof(TState).FullName == "Microsoft.Extensions.Logging.FormattedLogValues";
-            }
+            logProcessor.Post(entry);
         }
 
         public IDisposable BeginScope<TState>(TState state)
         {
-            // currently scope is not supported...
-            return NullDisposable.Instance;
+            return ScopeProvider?.Push(state) ?? NullDisposable.Instance;
         }
 
         public bool IsEnabled(LogLevel logLevel)
@@ -68,12 +43,7 @@ namespace ZLogger
 
         class NullDisposable : IDisposable
         {
-            public static IDisposable Instance = new NullDisposable();
-
-            NullDisposable()
-            {
-
-            }
+            public static readonly IDisposable Instance = new NullDisposable();
 
             public void Dispose()
             {
@@ -85,7 +55,7 @@ namespace ZLogger
         static class CreateLogEntry<T>
         // where T:IZLoggerState
         {
-            public static readonly Func<T, LogInfo, IZLoggerEntry>? factory;
+            public static readonly Func<T, LogInfo, LogScopeState?, IZLoggerEntry>? factory;
 
             static CreateLogEntry()
             {
@@ -98,7 +68,7 @@ namespace ZLogger
 
                         if (factoryField != null)
                         {
-                            factory = factoryField.GetValue(null) as Func<T, LogInfo, IZLoggerEntry>;
+                            factory = factoryField.GetValue(null) as Func<T, LogInfo, LogScopeState?, IZLoggerEntry>;
                         }
                     }
                     catch (Exception ex)

--- a/src/ZLogger/Entries/FormatLogEntry.cs
+++ b/src/ZLogger/Entries/FormatLogEntry.cs
@@ -12,7 +12,7 @@ namespace ZLogger.Entries
 {
     public struct FormatLogState<TPayload, T1> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -25,20 +25,20 @@ namespace ZLogger.Entries
             Arg1 = arg1;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1> Format;
@@ -51,30 +51,27 @@ namespace ZLogger.Entries
             Arg1 = arg1;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1>> cache = new();
 
         FormatLogState<TPayload, T1> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1> state)
+        public static FormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -83,6 +80,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -99,6 +97,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -118,17 +118,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1>> cache = new();
 
         PreparedFormatLogState<TPayload, T1> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1> state)
+        public static PreparedFormatLogEntry<TPayload, T1> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -137,6 +134,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -158,6 +156,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -177,7 +177,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -192,20 +192,20 @@ namespace ZLogger.Entries
             Arg2 = arg2;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2> Format;
@@ -220,30 +220,27 @@ namespace ZLogger.Entries
             Arg2 = arg2;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2>> cache = new();
 
         FormatLogState<TPayload, T1, T2> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2> state)
+        public static FormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -252,6 +249,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -268,6 +266,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -287,17 +287,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -306,6 +303,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -327,6 +325,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -346,7 +346,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -363,20 +363,20 @@ namespace ZLogger.Entries
             Arg3 = arg3;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3> Format;
@@ -393,30 +393,27 @@ namespace ZLogger.Entries
             Arg3 = arg3;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -425,6 +422,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -441,6 +439,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -460,17 +460,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -479,6 +476,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -500,6 +498,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -519,7 +519,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -538,20 +538,20 @@ namespace ZLogger.Entries
             Arg4 = arg4;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4> Format;
@@ -570,30 +570,27 @@ namespace ZLogger.Entries
             Arg4 = arg4;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -602,6 +599,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -618,6 +616,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -637,17 +637,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -656,6 +653,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -677,6 +675,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -696,7 +696,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -717,20 +717,20 @@ namespace ZLogger.Entries
             Arg5 = arg5;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5> Format;
@@ -751,30 +751,27 @@ namespace ZLogger.Entries
             Arg5 = arg5;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -783,6 +780,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -799,6 +797,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -818,17 +818,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -837,6 +834,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -858,6 +856,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -877,7 +877,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -900,20 +900,20 @@ namespace ZLogger.Entries
             Arg6 = arg6;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6> Format;
@@ -936,30 +936,27 @@ namespace ZLogger.Entries
             Arg6 = arg6;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -968,6 +965,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -984,6 +982,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1003,17 +1003,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1022,6 +1019,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1043,6 +1041,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1062,7 +1062,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1087,20 +1087,20 @@ namespace ZLogger.Entries
             Arg7 = arg7;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7> Format;
@@ -1125,30 +1125,27 @@ namespace ZLogger.Entries
             Arg7 = arg7;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1157,6 +1154,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1173,6 +1171,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1192,17 +1192,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1211,6 +1208,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1232,6 +1230,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1251,7 +1251,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1278,20 +1278,20 @@ namespace ZLogger.Entries
             Arg8 = arg8;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8> Format;
@@ -1318,30 +1318,27 @@ namespace ZLogger.Entries
             Arg8 = arg8;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1350,6 +1347,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1366,6 +1364,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1385,17 +1385,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1404,6 +1401,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1425,6 +1423,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1444,7 +1444,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1473,20 +1473,20 @@ namespace ZLogger.Entries
             Arg9 = arg9;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9> Format;
@@ -1515,30 +1515,27 @@ namespace ZLogger.Entries
             Arg9 = arg9;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1547,6 +1544,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1563,6 +1561,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1582,17 +1582,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1601,6 +1598,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1622,6 +1620,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1641,7 +1641,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1672,20 +1672,20 @@ namespace ZLogger.Entries
             Arg10 = arg10;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Format;
@@ -1716,30 +1716,27 @@ namespace ZLogger.Entries
             Arg10 = arg10;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1748,6 +1745,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1764,6 +1762,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1783,17 +1783,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1802,6 +1799,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1823,6 +1821,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1842,7 +1842,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -1875,20 +1875,20 @@ namespace ZLogger.Entries
             Arg11 = arg11;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Format;
@@ -1921,30 +1921,27 @@ namespace ZLogger.Entries
             Arg11 = arg11;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -1953,6 +1950,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -1969,6 +1967,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -1988,17 +1988,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2007,6 +2004,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2028,6 +2026,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2047,7 +2047,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -2082,20 +2082,20 @@ namespace ZLogger.Entries
             Arg12 = arg12;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Format;
@@ -2130,30 +2130,27 @@ namespace ZLogger.Entries
             Arg12 = arg12;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2162,6 +2159,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2178,6 +2176,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2197,17 +2197,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2216,6 +2213,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2237,6 +2235,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2256,7 +2256,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -2293,20 +2293,20 @@ namespace ZLogger.Entries
             Arg13 = arg13;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Format;
@@ -2343,30 +2343,27 @@ namespace ZLogger.Entries
             Arg13 = arg13;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2375,6 +2372,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2391,6 +2389,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2410,17 +2410,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2429,6 +2426,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2450,6 +2448,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2469,7 +2469,7 @@ namespace ZLogger.Entries
 
     public struct FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -2508,20 +2508,20 @@ namespace ZLogger.Entries
             Arg14 = arg14;
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Format;
@@ -2560,30 +2560,27 @@ namespace ZLogger.Entries
             Arg14 = arg14;
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new();
 
         FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state)
+        public static FormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in FormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2592,6 +2589,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2608,6 +2606,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -2627,17 +2627,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> cache = new();
 
         PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state)
+        public static PreparedFormatLogEntry<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -2646,6 +2643,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -2667,6 +2665,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 

--- a/src/ZLogger/Entries/FormatLogEntry.tt
+++ b/src/ZLogger/Entries/FormatLogEntry.tt
@@ -36,7 +36,7 @@ namespace ZLogger.Entries
 <# for(var i = 1; i <= 14; i++) { #>
     public struct FormatLogState<TPayload, <#= CreateTypeArgument(i) #>> : IZLoggerState
     {
-        public static readonly Func<FormatLogState<TPayload, <#= CreateTypeArgument(i) #>>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<FormatLogState<TPayload, <#= CreateTypeArgument(i) #>>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly string Format;
@@ -53,20 +53,20 @@ namespace ZLogger.Entries
 <# } #>
         }
 
-        static IZLoggerEntry factory(FormatLogState<TPayload, <#= CreateTypeArgument(i) #>> self, LogInfo logInfo)
+        static IZLoggerEntry factory(FormatLogState<TPayload, <#= CreateTypeArgument(i) #>> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>.Create(logInfo, this);
+            return FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>.Create(logInfo, this, scopeState);
         }
     }
 
     public struct PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>> : IZLoggerState
     {
-        public static readonly Func<PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>>, LogInfo, IZLoggerEntry> Factory = factory;
+        public static readonly Func<PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>>, LogInfo, LogScopeState?, IZLoggerEntry> Factory = factory;
 
         public readonly TPayload Payload;
         public readonly Utf8PreparedFormat<<#= CreateTypeArgument(i) #>> Format;
@@ -83,30 +83,27 @@ namespace ZLogger.Entries
 <# } #>
         }
 
-        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>> self, LogInfo logInfo)
+        static IZLoggerEntry factory(PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>> self, LogInfo logInfo, LogScopeState? scopeState)
         {
-            return self.CreateLogEntry(logInfo);
+            return self.CreateLogEntry(logInfo, scopeState);
         }
 
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo)
+        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
         {
-            return PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>.Create(logInfo, this);
+            return PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>.Create(logInfo, this, scopeState);
         }
     }
 
     public class FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>> cache = new ConcurrentQueue<FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>>();
+        static readonly ConcurrentQueue<FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>> cache = new();
 
         FormatLogState<TPayload, <#= CreateTypeArgument(i) #>> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        FormatLogEntry()
-        {
-        }
-
-        public static FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>> Create(in LogInfo logInfo, in FormatLogState<TPayload, <#= CreateTypeArgument(i) #>> state)
+        public static FormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>> Create(in LogInfo logInfo, in FormatLogState<TPayload, <#= CreateTypeArgument(i) #>> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -115,6 +112,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -131,6 +129,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 
@@ -150,17 +150,14 @@ namespace ZLogger.Entries
 
     public class PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>> cache = new ConcurrentQueue<PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>>();
+        static readonly ConcurrentQueue<PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>>> cache = new();
 
         PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>> state;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
-        PreparedFormatLogEntry()
-        {
-        }
-
-        public static PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>> state)
+        public static PreparedFormatLogEntry<TPayload, <#= CreateTypeArgument(i) #>> Create(in LogInfo logInfo, in PreparedFormatLogState<TPayload, <#= CreateTypeArgument(i) #>> state, LogScopeState? scopeState)
         {
             if (!cache.TryDequeue(out var result))
             {
@@ -169,6 +166,7 @@ namespace ZLogger.Entries
 
             result.LogInfo = logInfo;
             result.state = state;
+            result.ScopeState = scopeState;
             return result;
         }
 
@@ -190,6 +188,8 @@ namespace ZLogger.Entries
         {
             state = default;
             LogInfo = default!;
+            ScopeState?.Return();
+            ScopeState = default;
             cache.Enqueue(this);
         }
 

--- a/src/ZLogger/Entries/StringFormatterEntry.cs
+++ b/src/ZLogger/Entries/StringFormatterEntry.cs
@@ -7,8 +7,7 @@ namespace ZLogger.Entries
 {
     public class StringFormatterEntry<TState> : IZLoggerEntry
     {
-        static readonly ConcurrentQueue<StringFormatterEntry<TState>> cache = new ConcurrentQueue<StringFormatterEntry<TState>>();
-        static readonly byte[] newLineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
+        static readonly ConcurrentQueue<StringFormatterEntry<TState>> cache = new();
 
 #pragma warning disable CS8618
         TState state;
@@ -16,10 +15,11 @@ namespace ZLogger.Entries
         Func<TState, Exception?, string> formatter;
 
         public LogInfo LogInfo { get; private set; }
+        public LogScopeState? ScopeState { get; private set; }
 
 #pragma warning restore CS8618
 
-        public static StringFormatterEntry<TState> Create(LogInfo info, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        public static StringFormatterEntry<TState> Create(LogInfo info, TState state, LogScopeState? scopeState, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             if (!cache.TryDequeue(out var entry))
             {
@@ -30,6 +30,7 @@ namespace ZLogger.Entries
             entry.state = state;
             entry.exception = exception;
             entry.formatter = formatter;
+            entry.ScopeState = scopeState;
 
             return entry;
         }
@@ -67,6 +68,9 @@ namespace ZLogger.Entries
             this.LogInfo = default!;
             this.exception = default!;
             this.formatter = default!;
+            
+            ScopeState?.Return();
+            ScopeState = null;
         }
     }
 }

--- a/src/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
@@ -29,7 +29,7 @@ namespace ZLogger.Formatters
                 ExceptionFormatter(writer, ex);
             }
         }
-
+        
         static void DefaultExceptionLoggingFormatter(IBufferWriter<byte> writer, Exception exception)
         {
             // \n + exception

--- a/src/ZLogger/IZLoggerEntry.cs
+++ b/src/ZLogger/IZLoggerEntry.cs
@@ -7,6 +7,7 @@ namespace ZLogger
     public interface IZLoggerEntry
     {
         LogInfo LogInfo { get; }
+        LogScopeState? ScopeState { get; }
         void FormatUtf8(IBufferWriter<byte> writer, IZLoggerFormatter formatter);
         void SwitchCasePayload<TPayload>(Action<IZLoggerEntry, TPayload, object?> payloadCallback, object? state);
         object? GetPayload();

--- a/src/ZLogger/IZLoggerState.cs
+++ b/src/ZLogger/IZLoggerState.cs
@@ -2,6 +2,6 @@
 {
     public interface IZLoggerState
     {
-        IZLoggerEntry CreateLogEntry(LogInfo logInfo);
+        IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState);
     }
 }

--- a/src/ZLogger/LogScopeState.cs
+++ b/src/ZLogger/LogScopeState.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace ZLogger
+{
+    public class LogScopeState
+    {
+        const string DefaultScopeKeyName = "Scope";
+        static readonly ConcurrentQueue<LogScopeState> cache = new();        
+        
+        public bool IsEmpty => properties.Count <= 0;
+
+        public IReadOnlyList<KeyValuePair<string, object?>> Properties => properties;
+
+        readonly List<KeyValuePair<string, object?>> properties = new();
+
+        public static LogScopeState Create(IExternalScopeProvider scopeProvider)
+        {
+            if (!cache.TryDequeue(out var result))
+            {
+                result = new LogScopeState();
+            }
+            result.Snapshot(scopeProvider);
+            return result;
+        }
+        
+        public void Return()
+        {
+            Clear();
+            cache.Enqueue(this);
+        }
+
+        void Clear()
+        {
+            properties.Clear();
+        }
+        
+        void Snapshot(IExternalScopeProvider scopeProvider)
+        {
+            Clear();
+            scopeProvider.ForEachScope(static (state, props) =>
+            {
+                switch (state)
+                {
+                    // For example, using the `BeginScope(format, arg1, arg2, ...)` style, state is `FormattedLogValues : IEnumerable<KeyValuePair<string, object>>`.
+                    case IEnumerable<KeyValuePair<string, object?>> enumerable:
+                        props.AddRange(enumerable);
+                        break;
+                    case KeyValuePair<string, object?> prop:
+                        props.Add(prop);
+                        break;
+                    default:
+                        props.Add(new KeyValuePair<string, object?>(DefaultScopeKeyName, state));
+                        break;
+                }
+            }, properties);
+        }
+    }
+}

--- a/src/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
@@ -6,11 +6,12 @@ using System.Text;
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerConsole")]
-    public class ZLoggerConsoleLoggerProvider : ILoggerProvider
+    public class ZLoggerConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         internal const string DefaultOptionName = "ZLoggerConsole.Default";
 
-        AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamLineMessageWriter streamWriter;
+        IExternalScopeProvider? scopeProvider; 
 
         public ZLoggerConsoleLoggerProvider(IOptionsMonitor<ZLoggerOptions> options)
             : this(true, null, options)
@@ -36,12 +37,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, streamWriter);
+            return new AsyncProcessZLogger(categoryName, streamWriter)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             streamWriter.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger/Providers/ZLoggerFileLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerFileLoggerProvider.cs
@@ -1,19 +1,16 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.IO;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading;
 
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerFile")]
-    public class ZLoggerFileLoggerProvider : ILoggerProvider
+    public class ZLoggerFileLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         internal const string DefaultOptionName = "ZLoggerFile.Default";
 
-        AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamLineMessageWriter streamWriter;
+        IExternalScopeProvider? scopeProvider;
 
         public ZLoggerFileLoggerProvider(string filePath, IOptionsMonitor<ZLoggerOptions> options)
             : this(filePath, DefaultOptionName, options)
@@ -37,12 +34,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, streamWriter);
+            return new AsyncProcessZLogger(categoryName, streamWriter)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             streamWriter.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger/Providers/ZLoggerLogProcessorLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerLogProcessorLoggerProvider.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerLogProcessor")]
-    public class ZLoggerLogProcessorLoggerProvider : ILoggerProvider
+    public class ZLoggerLogProcessorLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
-        IAsyncLogProcessor processor;
+        readonly IAsyncLogProcessor processor;
+        IExternalScopeProvider? scopeProvider;
 
         public ZLoggerLogProcessorLoggerProvider(IAsyncLogProcessor processor)
         {
@@ -15,12 +15,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, processor);
+            return new AsyncProcessZLogger(categoryName, processor)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             processor.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
@@ -5,11 +5,12 @@ using System;
 namespace ZLogger.Providers
 {
     [ProviderAlias("ZLoggerRollingFile")]
-    public class ZLoggerRollingFileLoggerProvider : ILoggerProvider
+    public class ZLoggerRollingFileLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         internal const string DefaultOptionName = "ZLoggerRollingFile.Default";
 
-        AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamLineMessageWriter streamWriter;
+        IExternalScopeProvider? scopeProvider;
 
         public ZLoggerRollingFileLoggerProvider(Func<DateTimeOffset, int, string> fileNameSelector, Func<DateTimeOffset, DateTimeOffset> timestampPattern, int rollSizeKB, IOptionsMonitor<ZLoggerOptions> options)
             : this(fileNameSelector, timestampPattern, rollSizeKB, DefaultOptionName, options)
@@ -25,12 +26,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, streamWriter);
+            return new AsyncProcessZLogger(categoryName, streamWriter)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             streamWriter.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/src/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading;
 
 namespace ZLogger.Providers
 {

--- a/src/ZLogger/Providers/ZLoggerStreamLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerStreamLoggerProvider.cs
@@ -1,17 +1,16 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
 using System.IO;
 
 namespace ZLogger.Providers
 {
-
     [ProviderAlias("ZLoggerStream")]
-    public class ZLoggerStreamLoggerProvider : ILoggerProvider
+    public class ZLoggerStreamLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         internal const string DefaultOptionName = "ZLoggerStream.Default";
 
-        AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamLineMessageWriter streamWriter;
+        IExternalScopeProvider? scopeProvider;
 
         public ZLoggerStreamLoggerProvider(Stream stream, IOptionsMonitor<ZLoggerOptions> options)
             : this(stream, DefaultOptionName, options)
@@ -25,12 +24,20 @@ namespace ZLogger.Providers
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new AsyncProcessZLogger(categoryName, streamWriter);
+            return new AsyncProcessZLogger(categoryName, streamWriter)
+            {
+                ScopeProvider = scopeProvider
+            };
         }
 
         public void Dispose()
         {
             streamWriter.DisposeAsync().AsTask().Wait();
+        }
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.scopeProvider = scopeProvider;
         }
     }
 }

--- a/tests/ZLogger.MessagePack.Tests/FormatterTest.cs
+++ b/tests/ZLogger.MessagePack.Tests/FormatterTest.cs
@@ -1,62 +1,10 @@
 ﻿using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using FluentAssertions;
-using MessagePack;
-using MessagePack.Resolvers;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using ZLogger.MessagePack;
 
-namespace ZLogger.Tests
+namespace ZLogger.MessagePack.Tests
 {
-    [MessagePackObject(keyAsPropertyName: true)]
-    public class TestPayload
-    {
-        public int X { get; set; }
-    }
-    
-    class TestException : Exception
-    {
-        public TestException(string message) : base(message)
-        {
-        }
-        
-        public TestException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-    }
-    
-    class TestProcessor : IAsyncLogProcessor
-    {
-        public Queue<dynamic> EntryMessages = new Queue<dynamic>();
-        readonly ZLoggerOptions options;
-        readonly IZLoggerFormatter formatter;
-        readonly ArrayBufferWriter<byte> bufferWriter = new ArrayBufferWriter<byte>();
-
-        public dynamic Dequeue() => EntryMessages.Dequeue();
-
-        public TestProcessor(ZLoggerOptions options)
-        {
-            this.options = options;
-            formatter = options.CreateFormatter();
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
-
-        public void Post(IZLoggerEntry log)
-        {
-            log.FormatUtf8(bufferWriter, formatter);
-            var entry = MessagePackSerializer.Deserialize<dynamic>(bufferWriter.WrittenMemory, ContractlessStandardResolver.Options);
-            bufferWriter.Clear();
-            EntryMessages.Enqueue(entry);
-        }
-    }
-    
     public class FormatterTest
     {
         TestProcessor processor;

--- a/tests/ZLogger.MessagePack.Tests/ScopeTest.cs
+++ b/tests/ZLogger.MessagePack.Tests/ScopeTest.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace ZLogger.MessagePack.Tests
+{
+    public class ScopeTest
+    {
+        TestProcessor processor;
+        ILogger logger;
+
+        public ScopeTest()
+        {
+            var options = new ZLoggerOptions();
+            options.UseMessagePackFormatter();
+            
+            processor = new TestProcessor(options);
+
+            var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerLogProcessor(processor);
+            });
+            logger = loggerFactory.CreateLogger("test");
+        }
+        
+        [Fact]
+        public void BeginScope_FormattedLogValuesToMessagePack()
+        {
+            using (logger.BeginScope("({X}, {Y})", 111, null))
+            {
+                logger.ZLogInformation("FooBar{0} NanoNano{1}", 333, 444);
+            }
+
+            var msgpack = processor.Dequeue();
+            ((string)msgpack["Message"]).Should().Be("FooBar333 NanoNano444");
+            ((int)msgpack["X"]).Should().Be(111);
+            ((int)msgpack["Y"]).Should().Be(null);
+
+        }
+        
+        [Fact]
+        public void BeginScope_KeyValuePairToJson()
+        {
+            using (logger.BeginScope(new KeyValuePair<string, object?>("Hoge", "AAA")))
+            {
+                logger.ZLogInformation("FooBar{0} NanoNano{1}", 100, 200);
+            }
+
+            var msgpack = processor.Dequeue();
+            ((string)msgpack["Message"]).Should().Be("FooBar100 NanoNano200");
+            ((string)msgpack["Hoge"]).Should().Be("AAA");
+        }
+        
+        [Fact]
+        public void BeginScope_AnyScopeValueToJson()
+        {
+            using (logger.BeginScope(new TestPayload { X = 999 }))
+            {
+                logger.ZLogInformation("FooBar{0} NanoNano{1}", 100, 200);
+            }
+
+            var msgpack = processor.Dequeue();
+            ((string)msgpack["Message"]).Should().Be("FooBar100 NanoNano200");
+            ((int)msgpack["Scope"]["X"]).Should().Be(999);
+        }
+        
+        [Fact]
+        public void BeginScope_NestedToJson()
+        {
+            using (logger.BeginScope("A={A}", 100))
+            {
+                logger.ZLogInformation("Message 1");
+
+                using (logger.BeginScope("B={B}", 200))
+                {
+                    logger.ZLogInformation("Message 2");
+                }
+            }
+
+            var msgpack1 = processor.Dequeue();
+            var msgpack2 = processor.Dequeue();
+            ((string)msgpack1["Message"]).Should().Be("Message 1");
+            ((int)msgpack1["X"]).Should().Be(111);
+            ((bool)msgpack1.ContainsKey("Y")).Should().BeFalse();
+
+            ((string)msgpack2["Message"]).Should().Be("Message 2");
+            ((int)msgpack2["X"]).Should().Be(100);
+            ((int)msgpack2("Y")).Should().Be(200);
+        }
+    }
+}

--- a/tests/ZLogger.MessagePack.Tests/ScopeTest.cs
+++ b/tests/ZLogger.MessagePack.Tests/ScopeTest.cs
@@ -36,7 +36,7 @@ namespace ZLogger.MessagePack.Tests
             var msgpack = processor.Dequeue();
             ((string)msgpack["Message"]).Should().Be("FooBar333 NanoNano444");
             ((int)msgpack["X"]).Should().Be(111);
-            ((int)msgpack["Y"]).Should().Be(null);
+            ((string?)msgpack["Y"]).Should().Be(null);
 
         }
         
@@ -82,12 +82,12 @@ namespace ZLogger.MessagePack.Tests
             var msgpack1 = processor.Dequeue();
             var msgpack2 = processor.Dequeue();
             ((string)msgpack1["Message"]).Should().Be("Message 1");
-            ((int)msgpack1["X"]).Should().Be(111);
-            ((bool)msgpack1.ContainsKey("Y")).Should().BeFalse();
+            ((int)msgpack1["A"]).Should().Be(100);
+            ((bool)msgpack1.ContainsKey("B")).Should().BeFalse();
 
             ((string)msgpack2["Message"]).Should().Be("Message 2");
-            ((int)msgpack2["X"]).Should().Be(100);
-            ((int)msgpack2("Y")).Should().Be(200);
+            ((int)msgpack2["A"]).Should().Be(100);
+            ((int)msgpack2["B"]).Should().Be(200);
         }
     }
 }

--- a/tests/ZLogger.MessagePack.Tests/TestHelpers.cs
+++ b/tests/ZLogger.MessagePack.Tests/TestHelpers.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MessagePack;
+using MessagePack.Resolvers;
+
+namespace ZLogger.MessagePack.Tests
+{
+    [MessagePackObject(keyAsPropertyName: true)]
+    public class TestPayload
+    {
+        public int X { get; set; }
+    }
+    
+    class TestException : Exception
+    {
+        public TestException(string message) : base(message)
+        {
+        }
+        
+        public TestException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+    
+    class TestProcessor : IAsyncLogProcessor
+    {
+        public Queue<dynamic> EntryMessages = new();
+        readonly ZLoggerOptions options;
+        readonly IZLoggerFormatter formatter;
+        readonly ArrayBufferWriter<byte> bufferWriter = new();
+
+        public dynamic Dequeue() => EntryMessages.Dequeue();
+
+        public TestProcessor(ZLoggerOptions options)
+        {
+            this.options = options;
+            formatter = options.CreateFormatter();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return default;
+        }
+
+        public void Post(IZLoggerEntry log)
+        {
+            log.FormatUtf8(bufferWriter, formatter);
+            var entry = MessagePackSerializer.Deserialize<dynamic>(bufferWriter.WrittenMemory, ContractlessStandardResolver.Options);
+            bufferWriter.Clear();
+            EntryMessages.Enqueue(entry);
+        }
+    }    
+}

--- a/tests/ZLogger.MessagePack.Tests/ZLogger.MessagePack.Tests.csproj
+++ b/tests/ZLogger.MessagePack.Tests/ZLogger.MessagePack.Tests.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tests/ZLogger.Tests/MessageTest.cs
+++ b/tests/ZLogger.Tests/MessageTest.cs
@@ -2,41 +2,14 @@ using Cysharp.Text;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Xunit;
 using ZLogger.Formatters;
 
 namespace ZLogger.Tests
 {
-    public class TestProcessor : IAsyncLogProcessor
-    {
-        public Queue<string> EntryMessages = new Queue<string>();
-        readonly ZLoggerOptions options;
-        readonly IZLoggerFormatter formatter;
-
-        public string Dequeue() => EntryMessages.Dequeue();
-
-        public TestProcessor(ZLoggerOptions options)
-        {
-            this.options = options;
-            formatter = options.CreateFormatter();
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return default;
-        }
-
-        public void Post(IZLoggerEntry log)
-        {
-            EntryMessages.Enqueue(log.FormatToString(formatter));
-        }
-    }
-
     public class MessageTest
     {
         [Fact]

--- a/tests/ZLogger.Tests/ScopeTest.cs
+++ b/tests/ZLogger.Tests/ScopeTest.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+using ZLogger.Formatters;
+
+namespace ZLogger.Tests
+{
+    public class ScopeTest
+    {
+        TestProcessor processor;
+        ILogger logger;
+
+        public ScopeTest()
+        {
+            var options = new ZLoggerOptions();
+            options.UseJsonFormatter();
+            
+            processor = new TestProcessor(options);
+
+            var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerLogProcessor(processor);
+            });
+            logger = loggerFactory.CreateLogger("test");
+        }
+        
+        [Fact]
+        public void BeginScope_FormattedLogValuesToJson()
+        {
+            using (logger.BeginScope("({X}, {Y})", 111, null))
+            {
+                logger.ZLogInformation("FooBar{0} NanoNano{1}", 333, 444);
+            }
+
+            var doc = JsonDocument.Parse(processor.Dequeue()).RootElement;
+            doc.GetProperty("Message").GetString().Should().Be("FooBar333 NanoNano444");
+            doc.GetProperty("X").GetInt32().Should().Be(111);
+            doc.GetProperty("Y").ValueKind.Should().Be(JsonValueKind.Null);
+        }
+        
+        [Fact]
+        public void BeginScope_KeyValuePairToJson()
+        {
+            using (logger.BeginScope(new KeyValuePair<string, object?>("Hoge", "AAA")))
+            {
+                logger.ZLogInformation("FooBar{0} NanoNano{1}", 100, 200);
+            }
+
+            var doc = JsonDocument.Parse(processor.Dequeue()).RootElement;
+
+            doc.GetProperty("Message").GetString().Should().Be("FooBar100 NanoNano200");
+            doc.GetProperty("Hoge").GetString().Should().Be("AAA");
+        }
+        
+        [Fact]
+        public void BeginScope_AnyScopeValueToJson()
+        {
+            using (logger.BeginScope(new TestState { X = 999 }))
+            {
+                logger.ZLogInformation("FooBar{0} NanoNano{1}", 100, 200);
+            }
+
+            var doc = JsonDocument.Parse(processor.Dequeue()).RootElement;
+            doc.GetProperty("Message").GetString().Should().Be("FooBar100 NanoNano200");
+            
+            var scope = doc.GetProperty("Scope");
+            scope.GetProperty("X").GetInt32().Should().Be(999);
+        }
+        
+        [Fact]
+        public void BeginScope_NestedToJson()
+        {
+            using (logger.BeginScope("X={X}", 111))
+            {
+                logger.ZLogInformation("Message 1");
+
+                using (logger.BeginScope("Y={Y}", 222))
+                {
+                    logger.ZLogInformation("Message 2");
+                }
+            }
+
+            var log1 = JsonDocument.Parse(processor.Dequeue()).RootElement;
+            var log2 = JsonDocument.Parse(processor.Dequeue()).RootElement;
+
+            log1.GetProperty("Message").GetString().Should().Be("Message 1");
+            log1.GetProperty("X").GetInt32().Should().Be(111);
+            log1.TryGetProperty("Y", out _).Should().BeFalse();
+
+            log2.GetProperty("Message").GetString().Should().Be("Message 2");
+            log2.GetProperty("X").GetInt32().Should().Be(111);
+            log2.GetProperty("Y").GetInt32().Should().Be(222);
+        }
+    }
+}

--- a/tests/ZLogger.Tests/TestHelpers.cs
+++ b/tests/ZLogger.Tests/TestHelpers.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ZLogger.Tests
+{
+    class TestProcessor : IAsyncLogProcessor
+    {
+        public Queue<string> EntryMessages = new();
+        readonly IZLoggerFormatter formatter;
+
+        public string Dequeue() => EntryMessages.Dequeue();
+
+        public TestProcessor(ZLoggerOptions options)
+        {
+            formatter = options.CreateFormatter();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return default;
+        }
+
+        public void Post(IZLoggerEntry log)
+        {
+            EntryMessages.Enqueue(log.FormatToString(formatter));
+        }
+    }
+
+    class TestState
+    {
+        public int X { get; set; }
+    }    
+}


### PR DESCRIPTION
Add  implementation of `BeginScope(...)` for ILogger.

Note on implementation:
- Add `ISupportExternalScope` implementation to `ILoggerProvider`.
    - `ILoggerProvider` holds `IExternalScopeProvider`.
    - Also, ILogger (AsyncProcessZLogger) holds the `IExternalScopeProvider`. 
- Add `IZLoggerEntry.ScopeState` property.  It enables scope information to be retained.
    - The logger uses `IExternalScopeProvider.ForeEachScope` to create a copy of the value when creating a log entry.
    - Handles scope information as IEnumerable<KeyValuePair<string, object?>>.
