### PR TITLE
Fix memory leak

### DIFF
--- a/ZLogger.Generator/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/ZLogger.Generator/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -222,6 +222,10 @@ public partial class ZLoggerGenerator
             return default!;
         }
 
+        public void Dispose()
+        {
+        }
+
 """);
         }
 

--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -163,5 +163,9 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable
         CodeGeneratorUtil.ThrowArgumentOutOfRangeException();
         return default!;
     }
+
+    public void Dispose()
+    {
+    }
 }
 

--- a/src/ZLogger/AsyncStreamLineMessageWriter.cs
+++ b/src/ZLogger/AsyncStreamLineMessageWriter.cs
@@ -100,7 +100,7 @@ namespace ZLogger
                         {
                             info = value.LogInfo;
                             value.FormatUtf8(writer, formatter);
-                            value.Return();
+                            value.Dispose();
 
                             AppendLine(writer);
                         }

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 namespace ZLogger
 {
     // Implement for log state.
-    public interface IZLoggerFormattable
+    public interface IZLoggerFormattable : IDisposable
     {
         int ParameterCount { get; }
         bool IsSupportUtf8ParameterKey { get; }
@@ -13,7 +13,7 @@ namespace ZLogger
         void ToString(IBufferWriter<byte> writer);
 
         void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions);
-        
+
         ReadOnlySpan<byte> GetParameterKey(int index);
         string GetParameterKeyAsString(int index);
         object? GetParameterValue(int index);

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -7,7 +7,7 @@ using ZLogger.Internal;
 
 namespace ZLogger.LogStates
 {
-    public readonly struct InterpolatedStringLogState : IZLoggerFormattable, IDisposable
+    public readonly struct InterpolatedStringLogState : IZLoggerFormattable
     {
         static InterpolatedStringLogState()
         {
@@ -19,15 +19,12 @@ namespace ZLogger.LogStates
         {
             return ZLoggerEntry<InterpolatedStringLogState>.Create(logInfo, logState);
         }
-        
+
         static InterpolatedStringLogState CloneState(in InterpolatedStringLogState state)
         {
             var newParameters = ArrayPool<KeyValuePair<string, object?>>.Shared.Rent(state.ParameterCount);
-            for (var i = 0; i < state.ParameterCount; i++)
-            {
-                newParameters[i] = state.parameters[i];
-            }
-            
+            state.parameters.AsSpan(0, state.ParameterCount).CopyTo(newParameters.AsSpan());
+
             var newBuffer = ArrayBufferWriterPool.Rent();
             state.buffer.WrittenSpan.CopyTo(newBuffer.GetSpan(state.buffer.WrittenCount));
             newBuffer.Advance(state.buffer.WrittenCount);
@@ -59,7 +56,7 @@ namespace ZLogger.LogStates
         {
             return Encoding.UTF8.GetString(buffer.WrittenSpan);
         }
-        
+
         public void ToString(IBufferWriter<byte> writer)
         {
             var written = buffer.WrittenSpan;

--- a/src/ZLogger/LogStates/StringFormatterLogState.cs
+++ b/src/ZLogger/LogStates/StringFormatterLogState.cs
@@ -21,7 +21,7 @@ namespace ZLogger.LogStates
             this.originalState = originalState;
             this.exception = exception;
             this.formatter = formatter;
-            
+
             // In most case, TState is `Microsoft.Extensions.Logging.FormattedLogValues`.
             // TODO: can avoid boxing ?
             if (originalState is IReadOnlyList<KeyValuePair<string, object?>> x)
@@ -103,6 +103,10 @@ namespace ZLogger.LogStates
                 return originalStateParameters[index].Value?.GetType() ?? typeof(string);
             }
             throw new IndexOutOfRangeException(nameof(index));
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -12,10 +12,9 @@ namespace ZLogger
         LogInfo LogInfo { get; }
         LogScopeState? ScopeState { get; set; }
         void FormatUtf8(IBufferWriter<byte> writer, IZLoggerFormatter formatter); // TODO: 2 -> 1
-        void Return();
     }
 
-    // Create LogEntry from struct state without T constraints 
+    // Create LogEntry from struct state without T constraints
     public static class LogEntryFactory<T>
     {
         public static CreateLogEntry<T>? Create; // Register from each state static constructor
@@ -29,7 +28,7 @@ namespace ZLogger
         where TState : IZLoggerFormattable
     {
         static readonly ObjectPool<ZLoggerEntry<TState>> cache = new();
-        
+
         public LogScopeState? ScopeState { get; set; }
 
         ZLoggerEntry<TState>? next;
@@ -62,7 +61,7 @@ namespace ZLogger
 
         public int ParameterCount => state.ParameterCount;
         public bool IsSupportUtf8ParameterKey => state.IsSupportUtf8ParameterKey;
-        
+
         public ReadOnlySpan<byte> GetParameterKey(int index) => state.GetParameterKey(index);
         public string GetParameterKeyAsString(int index) => state.GetParameterKeyAsString(index);
 
@@ -74,7 +73,7 @@ namespace ZLogger
 
         public void ToString(IBufferWriter<byte> writer) => state.ToString(writer);
 
-        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions) 
+        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions)
             => state.WriteJsonParameterKeyValues(jsonWriter, jsonSerializerOptions);
 
         public LogInfo LogInfo => logInfo;
@@ -84,8 +83,9 @@ namespace ZLogger
             formatter.FormatLogEntry(writer, this);
         }
 
-        public void Return()
+        public void Dispose()
         {
+            state.Dispose();
             state = default!;
             logInfo = default!;
             ScopeState?.Return();
@@ -93,7 +93,7 @@ namespace ZLogger
             cache.TryPush(this);
         }
     }
-    
+
     public static class ZLoggerEntryExtensions
     {
         public static string FormatToString(this IZLoggerEntry entry, IZLoggerFormatter formatter)


### PR DESCRIPTION
Some Log states need to be Dispose, but I noticed that they are not disposing in AsyncLogProcessor.
Before I forget, I will create a PR for this fix.

I also honestly made IZLoggerFormattable IDisposable to make it easier to notice this problem. But please let me know if there is a problem.