### PR TITLE
Make line-break can be written or not per formatters

### DIFF
--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -64,7 +64,8 @@ namespace ZLogger.MessagePack
         public MessagePackSerializerOptions MessagePackSerializerOptions { get; set; } = MessagePackSerializer.DefaultOptions;
         public string MessagePropertyName { get; set; } = "Message";
         
-        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry, bool withLineBreak = true) 
+            where TEntry : IZLoggerEntry
         {
             var messagePackWriter = new MessagePackWriter(writer);
 

--- a/src/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Text;
+using ZLogger.Internal;
 
 namespace ZLogger.Formatters
 {
@@ -10,10 +11,9 @@ namespace ZLogger.Formatters
         public Action<IBufferWriter<byte>, LogInfo>? PrefixFormatter { get; set; }
         public Action<IBufferWriter<byte>, LogInfo>? SuffixFormatter { get; set; }
         public Action<IBufferWriter<byte>, Exception> ExceptionFormatter { get; set; } = DefaultExceptionLoggingFormatter;
-
-        static byte[] newLine = Encoding.UTF8.GetBytes(Environment.NewLine);
         
-        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry, bool withLineBreak = true) 
+            where TEntry : IZLoggerEntry
         {
             PrefixFormatter?.Invoke(writer, entry.LogInfo);
             entry.ToString(writer);
@@ -22,6 +22,11 @@ namespace ZLogger.Formatters
             if (entry.LogInfo.Exception is { } ex)
             {
                 ExceptionFormatter(writer, ex);
+            }
+
+            if (withLineBreak)
+            {
+                BufferWriterUtils.WriteNewLine(writer);
             }
         }
         

--- a/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
@@ -56,7 +56,8 @@ namespace ZLogger.Formatters
 
         Utf8JsonWriter? jsonWriter;
         
-        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry, bool withLineBreak = true) 
+            where TEntry : IZLoggerEntry
         {
             jsonWriter?.Reset(writer);
             jsonWriter ??= new Utf8JsonWriter(writer);
@@ -94,6 +95,11 @@ namespace ZLogger.Formatters
 
             jsonWriter.WriteEndObject();
             jsonWriter.Flush();
+
+            if (withLineBreak)
+            {
+                BufferWriterUtils.WriteNewLine(writer);
+            }
         }
 
         static JsonEncodedText LogLevelToEncodedText(LogLevel logLevel)

--- a/src/ZLogger/IZLoggerFormatter.cs
+++ b/src/ZLogger/IZLoggerFormatter.cs
@@ -5,7 +5,7 @@ namespace ZLogger
     // Define how write log entry(text, strctured-json, structured-msgpack, etc...)
     public interface IZLoggerFormatter
     {
-        void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry)
+        void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry, bool withLineBreak = true)
             where TEntry : IZLoggerEntry;
     }
 }

--- a/src/ZLogger/Internal/ArrayBufferWriterPool.cs
+++ b/src/ZLogger/Internal/ArrayBufferWriterPool.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 
@@ -9,7 +8,7 @@ namespace ZLogger.Internal
         [ThreadStatic]
         static ArrayBufferWriter<byte>? bufferWriter;
 
-        static ConcurrentQueue<ArrayBufferWriter<byte>> cache = new();
+        static readonly ConcurrentQueue<ArrayBufferWriter<byte>> cache = new();
 
         public static ArrayBufferWriter<byte> GetThreadStaticInstance()
         {

--- a/src/ZLogger/Internal/BufferWriterUtils.cs
+++ b/src/ZLogger/Internal/BufferWriterUtils.cs
@@ -1,0 +1,23 @@
+using System.Buffers;
+using System.Text;
+
+namespace ZLogger.Internal
+{
+    internal static class BufferWriterUtils
+    {
+        static readonly byte[] newLine = Encoding.UTF8.GetBytes(Environment.NewLine);
+        static readonly byte newLineBytes1 = newLine[0];
+        static readonly byte newLineBytes2 = newLine.Length >= 2 ? newLine[1] : default;
+
+        public static void WriteNewLine(IBufferWriter<byte> writer)
+        {
+            var span = writer.GetSpan(newLine.Length);
+            span[0] = newLineBytes1;
+            if (newLine.Length > 1)
+            {
+                span[1] = newLineBytes2;
+            }
+            writer.Advance(newLine.Length);
+        }
+    }
+}

--- a/src/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerConsoleLoggerProvider.cs
@@ -11,7 +11,7 @@ namespace ZLogger.Providers
         internal const string DefaultOptionName = "ZLoggerConsole.Default";
 
         readonly ZLoggerOptions options;
-        readonly AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamMessageWriter streamWriter;
         IExternalScopeProvider? scopeProvider; 
 
         public ZLoggerConsoleLoggerProvider(IOptionsMonitor<ZLoggerOptions> options)
@@ -33,7 +33,7 @@ namespace ZLogger.Providers
 
             this.options = options.Get(optionName ?? DefaultOptionName);
             var stream = outputToErrorStream ? Console.OpenStandardError() : Console.OpenStandardOutput();
-            this.streamWriter = new AsyncStreamLineMessageWriter(stream, this.options);
+            this.streamWriter = new AsyncStreamMessageWriter(stream, this.options);
         }
 
         public ILogger CreateLogger(string categoryName)

--- a/src/ZLogger/Providers/ZLoggerFileLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerFileLoggerProvider.cs
@@ -10,7 +10,7 @@ namespace ZLogger.Providers
         internal const string DefaultOptionName = "ZLoggerFile.Default";
 
         readonly ZLoggerOptions options;
-        readonly AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamMessageWriter streamWriter;
         IExternalScopeProvider? scopeProvider;
 
         public ZLoggerFileLoggerProvider(string filePath, IOptionsMonitor<ZLoggerOptions> options)
@@ -30,7 +30,7 @@ namespace ZLogger.Providers
 
             // useAsync:false, use sync(in thread) processor, don't use FileStream buffer(use buffer size = 1).
             var stream = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite, 1, false);
-            this.streamWriter = new AsyncStreamLineMessageWriter(stream, this.options);
+            this.streamWriter = new AsyncStreamMessageWriter(stream, this.options);
         }
 
         public ILogger CreateLogger(string categoryName)

--- a/src/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerRollingFileLoggerProvider.cs
@@ -10,7 +10,7 @@ namespace ZLogger.Providers
         internal const string DefaultOptionName = "ZLoggerRollingFile.Default";
 
         readonly ZLoggerOptions options;
-        readonly AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamMessageWriter streamWriter;
         IExternalScopeProvider? scopeProvider;
 
         public ZLoggerRollingFileLoggerProvider(Func<DateTimeOffset, int, string> fileNameSelector, Func<DateTimeOffset, DateTimeOffset> timestampPattern, int rollSizeKB, IOptionsMonitor<ZLoggerOptions> options)
@@ -22,7 +22,7 @@ namespace ZLogger.Providers
         {
             this.options = options.Get(optionName ?? DefaultOptionName);
             var stream = new RollingFileStream(fileNameSelector, timestampPattern, rollSizeKB, this.options);
-            this.streamWriter = new AsyncStreamLineMessageWriter(stream, this.options);
+            this.streamWriter = new AsyncStreamMessageWriter(stream, this.options);
         }
 
         public ILogger CreateLogger(string categoryName)

--- a/src/ZLogger/Providers/ZLoggerStreamLoggerProvider.cs
+++ b/src/ZLogger/Providers/ZLoggerStreamLoggerProvider.cs
@@ -10,7 +10,7 @@ namespace ZLogger.Providers
         internal const string DefaultOptionName = "ZLoggerStream.Default";
 
         readonly ZLoggerOptions options;
-        readonly AsyncStreamLineMessageWriter streamWriter;
+        readonly AsyncStreamMessageWriter streamWriter;
         IExternalScopeProvider? scopeProvider;
 
         public ZLoggerStreamLoggerProvider(Stream stream, IOptionsMonitor<ZLoggerOptions> options)
@@ -21,7 +21,7 @@ namespace ZLogger.Providers
         public ZLoggerStreamLoggerProvider(Stream stream, string? optionName, IOptionsMonitor<ZLoggerOptions> options)
         {
             this.options = options.Get(optionName ?? DefaultOptionName);
-            this.streamWriter = new AsyncStreamLineMessageWriter(stream, this.options);
+            this.streamWriter = new AsyncStreamMessageWriter(stream, this.options);
         }
 
         public ILogger CreateLogger(string categoryName)

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using ZLogger.Internal;
@@ -102,7 +101,7 @@ namespace ZLogger
             var buffer = ArrayBufferWriterPool.Rent();
             try
             {
-                formatter.FormatLogEntry(buffer, entry);
+                formatter.FormatLogEntry(buffer, entry, withLineBreak: false);
                 return Encoding.UTF8.GetString(buffer.WrittenSpan);
             }
             finally


### PR DESCRIPTION
Currently, AsyncMessageWriter writes a newline code for each entry.
However, for example, the messagepack format should be easier to handle without the newline code.

We would be make it possible to set whether or not a line break code is written for each formatter.