### PR TITLE
Add default behavior of parameter key name 

### DIFF
--- a/ZLogger.Generator/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/ZLogger.Generator/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -85,6 +85,7 @@ public partial class ZLoggerGenerator
         {
             return ZLoggerEntry<{{stateTypeName}}>.Create(info, this);
         }
+        
 """);
 
             EmitIZLoggerFormattableMethods(method);
@@ -155,7 +156,7 @@ public partial class ZLoggerGenerator
 
             //void WriteJsonParameterKeyValues(Utf8JsonWriter writer, JsonSerializerOptions jsonSerializerOptions);
             sb.AppendLine($$"""
-        public void WriteJsonParameterKeyValues(Utf8JsonWriter writer, JsonSerializerOptions jsonSerializerOptions)
+        public void WriteJsonParameterKeyValues(Utf8JsonWriter writer, JsonSerializerOptions jsonSerializerOptions, ZLoggerOptions options)
         {
 {{ForEachLine("            ", methodParameters, x => x.ConvertJsonWriteMethod())}}
         }
@@ -176,7 +177,7 @@ public partial class ZLoggerGenerator
             return default!;
         }
 
-        public string GetParameterKeyAsString(int index)
+        public ReadOnlySpan<char> GetParameterKeyAsString(int index)
         {
             switch (index)
             {

--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -76,7 +76,7 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable
         stringWriter.Flush();
     }
 
-    public void WriteJsonParameterKeyValues(Utf8JsonWriter writer, JsonSerializerOptions jsonSerializerOptions)
+    public void WriteJsonParameterKeyValues(Utf8JsonWriter writer, JsonSerializerOptions jsonSerializerOptions, ZLoggerOptions options)
     {
         writer.WriteString(_jsonParameter_hostName, this.hostName);
         writer.WriteNumber(_jsonParameter_ipAddress, this.ipAddress);

--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -93,7 +93,7 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable
         return default!;
     }
 
-    public string GetParameterKeyAsString(int index)
+    public ReadOnlySpan<char> GetParameterKeyAsString(int index)
     {
         switch (index)
         {

--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -331,8 +331,8 @@ namespace ZLogger.MessagePack
                     // If `BeginScope(format, arg1, arg2)` style is used, the first argument `format` string is passed with this name
                     if (key == "{OriginalFormat}")
                         continue;
-                    
-                    messagePackWriter.Write(key);
+
+                    WriteKeyName(ref messagePackWriter, key);
                     if (value == null)
                     {
                         messagePackWriter.WriteNil();

--- a/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
@@ -15,7 +15,7 @@ namespace ZLogger.Formatters
         {
             return options.UseFormatter(() =>
             {
-                var formatter = new SystemTextJsonZLoggerFormatter();
+                var formatter = new SystemTextJsonZLoggerFormatter(options);
                 jsonConfigure?.Invoke(formatter);
                 return formatter;
             });
@@ -54,7 +54,13 @@ namespace ZLogger.Formatters
             Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
         };
 
+        readonly ZLoggerOptions options;
         Utf8JsonWriter? jsonWriter;
+
+        public SystemTextJsonZLoggerFormatter(ZLoggerOptions options)
+        {
+            this.options = options;
+        }
         
         public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
         {
@@ -69,7 +75,7 @@ namespace ZLogger.Formatters
             entry.ToString(bufferWriter);
             jsonWriter.WriteString(MessagePropertyName, bufferWriter.WrittenSpan);
             
-            entry.WriteJsonParameterKeyValues(jsonWriter, JsonSerializerOptions);
+            entry.WriteJsonParameterKeyValues(jsonWriter, JsonSerializerOptions, options);
             
             if (entry.ScopeState is { IsEmpty: false } scopeState)
             {

--- a/src/ZLogger/IKeyNameMutator.cs
+++ b/src/ZLogger/IKeyNameMutator.cs
@@ -3,6 +3,7 @@ namespace ZLogger
     public static class KeyNameMutator
     {
         public static readonly IKeyNameMutator LowercaseInitial = new LowercaseInitialMutator();
+        public static readonly IKeyNameMutator UppercaseInitial = new UppercaseInitialMutator();
     }
 
     public interface IKeyNameMutator
@@ -27,6 +28,32 @@ namespace ZLogger
             }
 
             destination[0] = char.ToLowerInvariant(source[0]);
+            if (source.Length > 1)
+            {
+                source[1..].CopyTo(destination[1..]);
+            }
+            written = source.Length;
+            return true;
+        }
+    }
+
+    class UppercaseInitialMutator : IKeyNameMutator
+    {
+        public bool TryMutate(ReadOnlySpan<char> source, scoped Span<char> destination, out int written)
+        {
+            if (source.Length >= destination.Length)
+            {
+                written = default;
+                return false;
+            }
+
+            if (source.Length <= 0)
+            {
+                written = 0;
+                return true;
+            }
+
+            destination[0] = char.ToUpperInvariant(source[0]);
             if (source.Length > 1)
             {
                 source[1..].CopyTo(destination[1..]);

--- a/src/ZLogger/IKeyNameMutator.cs
+++ b/src/ZLogger/IKeyNameMutator.cs
@@ -1,0 +1,38 @@
+namespace ZLogger
+{
+    public static class KeyNameMutator
+    {
+        public static readonly IKeyNameMutator LowercaseInitial = new LowercaseInitialMutator();
+    }
+
+    public interface IKeyNameMutator
+    {
+        bool TryMutate(ReadOnlySpan<char> source, scoped Span<char> destination, out int written);
+    }
+    
+    class LowercaseInitialMutator : IKeyNameMutator
+    {
+        public bool TryMutate(ReadOnlySpan<char> source, scoped Span<char> destination, out int written)
+        {
+            if (source.Length >= destination.Length)
+            {
+                written = default;
+                return false;
+            }
+
+            if (source.Length <= 0)
+            {
+                written = 0;
+                return true;
+            }
+
+            destination[0] = char.ToLowerInvariant(source[0]);
+            if (source.Length > 1)
+            {
+                source[1..].CopyTo(destination[1..]);
+            }
+            written = source.Length;
+            return true;
+        }
+    }
+}

--- a/src/ZLogger/IKeyNameMutator.cs
+++ b/src/ZLogger/IKeyNameMutator.cs
@@ -15,7 +15,7 @@ namespace ZLogger
     {
         public bool TryMutate(ReadOnlySpan<char> source, scoped Span<char> destination, out int written)
         {
-            if (source.Length >= destination.Length)
+            if (source.Length > destination.Length)
             {
                 written = default;
                 return false;
@@ -41,7 +41,7 @@ namespace ZLogger
     {
         public bool TryMutate(ReadOnlySpan<char> source, scoped Span<char> destination, out int written)
         {
-            if (source.Length >= destination.Length)
+            if (source.Length > destination.Length)
             {
                 written = default;
                 return false;

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -13,7 +13,7 @@ namespace ZLogger
         string ToString();
         void ToString(IBufferWriter<byte> writer);
 
-        void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions);
+        void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, ZLoggerOptions options);
 
         ReadOnlySpan<byte> GetParameterKey(int index);
         ReadOnlySpan<char> GetParameterKeyAsString(int index);

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Text.Json;
 
 namespace ZLogger
@@ -17,7 +16,7 @@ namespace ZLogger
         void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions);
 
         ReadOnlySpan<byte> GetParameterKey(int index);
-        string GetParameterKeyAsString(int index);
+        ReadOnlySpan<char> GetParameterKeyAsString(int index);
         object? GetParameterValue(int index);
         T? GetParameterValue<T>(int index);
         Type GetParameterType(int index);

--- a/src/ZLogger/Internal/CallerArgumentExpressionParser.cs
+++ b/src/ZLogger/Internal/CallerArgumentExpressionParser.cs
@@ -37,7 +37,6 @@ namespace ZLogger.Internal
                                 SkipRawStringLiteral(ref i, quoteCharCount, expressionString);
                                 break;
                         }
-
                         break;
                     case '@':
                         if (i + 1 < expressionString.Length && expressionString[i + 1] == '"')

--- a/src/ZLogger/Internal/CallerArgumentExpressionParser.cs
+++ b/src/ZLogger/Internal/CallerArgumentExpressionParser.cs
@@ -1,0 +1,129 @@
+namespace ZLogger.Internal
+{
+    internal static class CallerArgumentExpressionParser
+    {
+        public static ReadOnlySpan<char> GetParameterizedName(ReadOnlySpan<char> expressionString)
+        {
+            var lastDotPos = -1;
+            var lastOpenParenthesisPos = -1;
+            for (var i = 0; i < expressionString.Length; i++)
+            {
+                var ch = expressionString[i];
+                switch (ch)
+                {
+                    case '"':
+                        // escaped 
+                        var quoteCharCount = 1;
+                        while (i + quoteCharCount < expressionString.Length)
+                        {
+                            if (expressionString[i + quoteCharCount] != '"')
+                            {
+                                break;
+                            }
+                            quoteCharCount++;
+                        }
+
+                        i += quoteCharCount; // Skip continuous quotes
+
+                        switch (quoteCharCount)
+                        {
+                            case 1:
+                                SkipStringLiteral(ref i, expressionString);
+                                break;
+                            case 2:
+                                // Empty string
+                                break;
+                            case >= 3:
+                                SkipRawStringLiteral(ref i, quoteCharCount, expressionString);
+                                break;
+                        }
+
+                        break;
+                    case '@':
+                        if (i + 1 < expressionString.Length && expressionString[i + 1] == '"')
+                        {
+                            i += 2; // Skip @"
+                            SkipVerbatimStringLiteral(ref i, expressionString);
+                        }
+
+                        break;
+                    case '.':
+                        lastDotPos = i;
+                        break;
+                    case '(':
+                        lastOpenParenthesisPos = i;
+                        break;
+                }
+            }
+            
+            var start = lastDotPos >= 0 ? lastDotPos + 1 : 0;
+            var last = lastOpenParenthesisPos >= 0 ? lastOpenParenthesisPos - 1 : expressionString.Length - 1;
+            var count = last - start + 1;
+            return expressionString.Slice(start, count);
+        }
+        
+        static void SkipStringLiteral(ref int offset, ReadOnlySpan<char> expressionString)
+        {
+            while (offset < expressionString.Length)
+            {
+                var ch = expressionString[offset];
+                switch (ch)
+                {
+                    case '\\':
+                        if (offset + 1 < expressionString.Length && expressionString[offset + 1] == '"')
+                        {
+                            offset += 2; // skip escaped double quote
+                        }
+                        break;
+                    case '"':
+                        offset++;
+                        return;
+                }
+                offset++;
+            }
+        }
+        
+        static void SkipVerbatimStringLiteral(ref int offset, ReadOnlySpan<char> expressionString)
+        {
+            while (offset < expressionString.Length)
+            {
+                var ch = expressionString[offset];
+                if (ch == '"')
+                {
+                    if (offset + 1 < expressionString.Length && expressionString[offset + 1] == '"')
+                    {
+                        offset += 2; // skip escaped double quote
+                    }
+                    else
+                    {
+                        offset++;
+                        return;
+                    }
+                }
+                offset++;
+            }
+        }
+
+        static void SkipRawStringLiteral(ref int offset, int quoteCount, ReadOnlySpan<char> expressionString)
+        {
+            var closeQuoteCount = 0;
+            while (offset < expressionString.Length)
+            {
+                if (expressionString[offset] == '"')
+                {
+                    closeQuoteCount++;
+                    if (closeQuoteCount >= quoteCount)
+                    {
+                        offset++;
+                        return;
+                    }
+                }
+                else
+                {
+                    closeQuoteCount = 0;
+                }
+                offset++;
+            }
+        }
+    }    
+}

--- a/src/ZLogger/Internal/MagicalBox.cs
+++ b/src/ZLogger/Internal/MagicalBox.cs
@@ -278,7 +278,7 @@ internal unsafe partial struct MagicalBox
         return true;
     }
 
-    public bool TryReadTo(Type type, int offset, string propertyName, Utf8JsonWriter jsonWriter)
+    public bool TryReadTo(Type type, int offset, Utf8JsonWriter jsonWriter)
     {
         if (offset < 0) return false;
 
@@ -286,49 +286,49 @@ internal unsafe partial struct MagicalBox
         switch (code)
         {
             case TypeCode.Boolean:
-                jsonWriter.WriteBoolean(propertyName, Read<Boolean>(offset));
+                jsonWriter.WriteBooleanValue(Read<Boolean>(offset));
                 return true;
             case TypeCode.Char:
                 var c = Read<char>(offset);
                 Span<char> cs = stackalloc char[1];
                 cs[0] = c;
-                jsonWriter.WriteString(propertyName, cs);
+                jsonWriter.WriteStringValue(cs);
                 break;
             case TypeCode.SByte:
-                jsonWriter.WriteNumber(propertyName, Read<SByte>(offset));
+                jsonWriter.WriteNumberValue(Read<SByte>(offset));
                 return true;
             case TypeCode.Byte:
-                jsonWriter.WriteNumber(propertyName, Read<Byte>(offset));
+                jsonWriter.WriteNumberValue(Read<Byte>(offset));
                 return true;
             case TypeCode.Int16:
-                jsonWriter.WriteNumber(propertyName, Read<Int16>(offset));
+                jsonWriter.WriteNumberValue(Read<Int16>(offset));
                 return true;
             case TypeCode.UInt16:
-                jsonWriter.WriteNumber(propertyName, Read<UInt16>(offset));
+                jsonWriter.WriteNumberValue(Read<UInt16>(offset));
                 return true;
             case TypeCode.Int32:
-                jsonWriter.WriteNumber(propertyName, Read<Int32>(offset));
+                jsonWriter.WriteNumberValue(Read<Int32>(offset));
                 return true;
             case TypeCode.UInt32:
-                jsonWriter.WriteNumber(propertyName, Read<UInt32>(offset));
+                jsonWriter.WriteNumberValue(Read<UInt32>(offset));
                 return true;
             case TypeCode.Int64:
-                jsonWriter.WriteNumber(propertyName, Read<Int64>(offset));
+                jsonWriter.WriteNumberValue(Read<Int64>(offset));
                 return true;
             case TypeCode.UInt64:
-                jsonWriter.WriteNumber(propertyName, Read<UInt64>(offset));
+                jsonWriter.WriteNumberValue(Read<UInt64>(offset));
                 return true;
             case TypeCode.Single:
-                jsonWriter.WriteNumber(propertyName, Read<Single>(offset));
+                jsonWriter.WriteNumberValue(Read<Single>(offset));
                 return true;
             case TypeCode.Double:
-                jsonWriter.WriteNumber(propertyName, Read<Double>(offset));
+                jsonWriter.WriteNumberValue(Read<Double>(offset));
                 return true;
             case TypeCode.Decimal:
-                jsonWriter.WriteNumber(propertyName, Read<Decimal>(offset));
+                jsonWriter.WriteNumberValue(Read<Decimal>(offset));
                 return true;
             case TypeCode.DateTime:
-                jsonWriter.WriteString(propertyName, Read<DateTime>(offset));
+                jsonWriter.WriteStringValue(Read<DateTime>(offset));
                 return true;
             default:
                 break;
@@ -341,25 +341,25 @@ internal unsafe partial struct MagicalBox
             var name = dict.GetJsonEncodedName(rawValue);
             if (name == null)
             {
-                jsonWriter.WriteString(propertyName, converter(rawValue));
+                jsonWriter.WriteStringValue(converter(rawValue));
             }
             else
             {
-                jsonWriter.WriteString(propertyName, name.Value);
+                jsonWriter.WriteStringValue(name.Value);
             }
         }
 
         if (type == typeof(Guid))
         {
-            jsonWriter.WriteString(propertyName, Read<Guid>(offset));
+            jsonWriter.WriteStringValue(Read<Guid>(offset));
         }
         else if (type == typeof(DateTime))
         {
-            jsonWriter.WriteString(propertyName, Read<DateTime>(offset));
+            jsonWriter.WriteStringValue(Read<DateTime>(offset));
         }
         else if (type == typeof(DateTimeOffset))
         {
-            jsonWriter.WriteString(propertyName, Read<DateTimeOffset>(offset));
+            jsonWriter.WriteStringValue(Read<DateTimeOffset>(offset));
         }
 
         return true;

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers;
 using System.Text.Json;
 using ZLogger.Internal;
@@ -73,7 +72,7 @@ namespace ZLogger.LogStates
                     continue;
                 }
 
-                jsonWriter.WritePropertyName(p.GetParameterizeName());
+                jsonWriter.WritePropertyName(p.GetParameterizeNamePart());
 
                 var value = magicalBox.Read(p.Type, p.BoxOffset);
                 if (value != null)
@@ -92,9 +91,9 @@ namespace ZLogger.LogStates
             throw new NotSupportedException();
         }
 
-        public string GetParameterKeyAsString(int index)
+        public ReadOnlySpan<char> GetParameterKeyAsString(int index)
         {
-            return parameters[index].Name;
+            return parameters[index].GetParameterizeNamePart();
         }
 
         public object? GetParameterValue(int index)

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -62,7 +62,7 @@ namespace ZLogger.LogStates
             messageSequence.ToString(writer, magicalBox, parameters);
         }
 
-        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions)
+        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, ZLoggerOptions options)
         {
             for (var i = 0; i < ParameterCount; i++)
             {
@@ -72,7 +72,7 @@ namespace ZLogger.LogStates
                     continue;
                 }
 
-                jsonWriter.WritePropertyName(p.GetParameterizeNamePart());
+                p.WriteJsonKeyName(jsonWriter, options.KeyNameMutator);
 
                 var value = magicalBox.Read(p.Type, p.BoxOffset);
                 if (value != null)
@@ -93,7 +93,7 @@ namespace ZLogger.LogStates
 
         public ReadOnlySpan<char> GetParameterKeyAsString(int index)
         {
-            return parameters[index].GetParameterizeNamePart();
+            return parameters[index].ParseKeyName();
         }
 
         public object? GetParameterValue(int index)

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text.Json;
+using ZLogger.Formatters;
 using ZLogger.Internal;
 
 namespace ZLogger.LogStates
@@ -67,7 +68,7 @@ namespace ZLogger.LogStates
             for (var i = 0; i < ParameterCount; i++)
             {
                 ref var p = ref parameters[i];
-                p.WriteJsonKeyName(jsonWriter, options.KeyNameMutator);
+                SystemTextJsonZLoggerFormatter.WriteMutatedJsonKeyName(p.ParseKeyName(), jsonWriter, options.KeyNameMutator);
                 
                 if (magicalBox.TryReadTo(p.Type, p.BoxOffset, jsonWriter))
                 {

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -67,12 +67,12 @@ namespace ZLogger.LogStates
             for (var i = 0; i < ParameterCount; i++)
             {
                 ref var p = ref parameters[i];
-                if (magicalBox.TryReadTo(p.Type, p.BoxOffset, p.Name, jsonWriter))
+                p.WriteJsonKeyName(jsonWriter, options.KeyNameMutator);
+                
+                if (magicalBox.TryReadTo(p.Type, p.BoxOffset, jsonWriter))
                 {
                     continue;
                 }
-
-                p.WriteJsonKeyName(jsonWriter, options.KeyNameMutator);
 
                 var value = magicalBox.Read(p.Type, p.BoxOffset);
                 if (value != null)

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -73,7 +73,7 @@ namespace ZLogger.LogStates
                     continue;
                 }
 
-                jsonWriter.WritePropertyName(p.Name);
+                jsonWriter.WritePropertyName(p.GetParameterizeName());
 
                 var value = magicalBox.Read(p.Type, p.BoxOffset);
                 if (value != null)

--- a/src/ZLogger/LogStates/StringFormatterLogState.cs
+++ b/src/ZLogger/LogStates/StringFormatterLogState.cs
@@ -48,7 +48,7 @@ namespace ZLogger.LogStates
             writer.Advance(bytesWritten);
         }
 
-        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions)
+        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, ZLoggerOptions options)
         {
             if (originalStateParameters == null) return;
 

--- a/src/ZLogger/LogStates/StringFormatterLogState.cs
+++ b/src/ZLogger/LogStates/StringFormatterLogState.cs
@@ -73,7 +73,7 @@ namespace ZLogger.LogStates
             throw new NotSupportedException();
         }
 
-        public string GetParameterKeyAsString(int index)
+        public ReadOnlySpan<char> GetParameterKeyAsString(int index)
         {
             if (originalStateParameters != null)
             {

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using ZLogger.Internal;
@@ -59,7 +58,7 @@ namespace ZLogger
         public bool IsSupportUtf8ParameterKey => state.IsSupportUtf8ParameterKey;
 
         public ReadOnlySpan<byte> GetParameterKey(int index) => state.GetParameterKey(index);
-        public string GetParameterKeyAsString(int index) => state.GetParameterKeyAsString(index);
+        public ReadOnlySpan<char> GetParameterKeyAsString(int index) => state.GetParameterKeyAsString(index);
 
         public Type GetParameterType(int index) => state.GetParameterType(index);
 

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -68,8 +68,8 @@ namespace ZLogger
 
         public void ToString(IBufferWriter<byte> writer) => state.ToString(writer);
 
-        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions)
-            => state.WriteJsonParameterKeyValues(jsonWriter, jsonSerializerOptions);
+        public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, ZLoggerOptions options)
+            => state.WriteJsonParameterKeyValues(jsonWriter, jsonSerializerOptions, options);
 
         public LogInfo LogInfo => logInfo;
 

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -322,14 +322,7 @@ namespace ZLogger
 
         public ReadOnlySpan<char> GetParameterizeNamePart()
         {
-            var lastDotPos = Name.LastIndexOf('.');
-            var lastOpenParenthesisPos = Name.LastIndexOf('(');
-
-            var start = lastDotPos >= 0 ? lastDotPos + 1 : 0;
-            var last = lastOpenParenthesisPos >= 0 ? lastOpenParenthesisPos - 1 : Name.Length - 1;
-            var count = last - start + 1;
-            
-            return Name.AsSpan(start, count);
+            return CallerArgumentExpressionParser.GetParameterizedName(Name);
         }
     }
 }

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -319,5 +319,17 @@ namespace ZLogger
             BoxOffset = boxOffset;
             BoxedValue = boxedValue;
         }
+
+        public ReadOnlySpan<char> GetParameterizeName()
+        {
+            var lastDotPos = Name.LastIndexOf('.');
+            var lastOpenParenthesisPos = Name.LastIndexOf('(');
+
+            var start = lastDotPos >= 0 ? lastDotPos + 1 : 0;
+            var last = lastOpenParenthesisPos >= 0 ? lastOpenParenthesisPos - 1 : Name.Length - 1;
+            var count = last - start + 1;
+            
+            return Name.AsSpan(start, count);
+        }
     }
 }

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -320,7 +320,7 @@ namespace ZLogger
             BoxedValue = boxedValue;
         }
 
-        public ReadOnlySpan<char> GetParameterizeName()
+        public ReadOnlySpan<char> GetParameterizeNamePart()
         {
             var lastDotPos = Name.LastIndexOf('.');
             var lastOpenParenthesisPos = Name.LastIndexOf('(');

--- a/src/ZLogger/ZLoggerOptions.cs
+++ b/src/ZLogger/ZLoggerOptions.cs
@@ -6,6 +6,7 @@ namespace ZLogger
     public class ZLoggerOptions
     {
         public Action<LogInfo, Exception>? InternalErrorLogger { get; set; }
+        
         public TimeSpan? FlushRate { get; set; }
         public bool IncludeScopes { get; set; }
 

--- a/src/ZLogger/ZLoggerOptions.cs
+++ b/src/ZLogger/ZLoggerOptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using ZLogger.Formatters;
+﻿using ZLogger.Formatters;
 
 namespace ZLogger
 {
@@ -9,6 +8,7 @@ namespace ZLogger
         
         public TimeSpan? FlushRate { get; set; }
         public bool IncludeScopes { get; set; }
+        public IKeyNameMutator? KeyNameMutator { get; set; }
 
         Func<IZLoggerFormatter> formatterFactory = DefaultFormatterFactory;
 

--- a/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
+++ b/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
@@ -24,23 +24,27 @@ namespace ZLogger.Tests
         [Fact]
         public void GetParameterizeName_WithStringLiteral()
         {
-            var result1 = CallerArgumentExpressionParser.GetParameterizedName("Hoge.Moge(\"aaa.aaa(\"\"aaa\"\")\")");
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName("""Hoge.Moge("aaa.aaa(\"123\")")""");
             result1.ToString().Should().Be("Moge");
+            
+            var result2 = CallerArgumentExpressionParser.GetParameterizedName("""Hoge.Moge("aaa.aaa(\"123\")").Fuga("bbb")""");
+            result2.ToString().Should().Be("Fuga");
         }
         
         [Fact]
         public void GetLastPropertyName_WithVerbatimStringLiteral()
         {
-            var result1 = CallerArgumentExpressionParser.GetParameterizedName("Hoge.Moge(@\"aaa.aaa(\\\"aaa\\\")\")");
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName("""Hoge.Moge(@"aaa.aaa(""123"")")""");
             result1.ToString().Should().Be("Moge");
+            
+            var result2 = CallerArgumentExpressionParser.GetParameterizedName("""Hoge.Moge(@"aaa.aaa(""123"")").Fuga("bbb")""");
+            result2.ToString().Should().Be("Fuga");
         }
         
         [Fact]
         public void GetLastPropertyName_WithRawStringLiteral()
         {
-            var result1 = CallerArgumentExpressionParser.GetParameterizedName(""""
-Hoge.Moge("""aaa...""bbb(((()))""..ccc""")
-"""");
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName(""""Hoge.Moge("""aaa...""bbb(((()))""..ccc""")"""");
             result1.ToString().Should().Be("Moge");
             
             var result2 = CallerArgumentExpressionParser.GetParameterizedName("""""

--- a/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
+++ b/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
@@ -1,23 +1,56 @@
 using FluentAssertions;
+using ZLogger.Internal;
 
 namespace ZLogger.Tests
 {
     public class InterpolatedStringParameterTest
     {
         [Fact]
-        public void GetLastPropertyName()
+        public void GetParameterizeName()
         {
-            var result1 = new InterpolatedStringParameter(typeof(int), "id", 0, null, 0, null).GetParameterizeNamePart();
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName("id");
             result1.ToString().Should().Be("id");
-            
-            var result2 = new InterpolatedStringParameter(typeof(int), "HttpContext.RequestId", 0, null, 0, null).GetParameterizeNamePart();
+
+            var result2 = CallerArgumentExpressionParser.GetParameterizedName("HttpContext.RequestId");
             result2.ToString().Should().Be("RequestId");
-            
-            var result3 = new InterpolatedStringParameter(typeof(int), "MyNamespace.MyClass.Foo.Bar.Buz", 0, null, 0, null).GetParameterizeNamePart();
+
+            var result3 = CallerArgumentExpressionParser.GetParameterizedName("MyNamespace.MyClass.Foo.Bar.Buz");
             result3.ToString().Should().Be("Buz");
-            
-            var result4 = new InterpolatedStringParameter(typeof(int), "myInstance.DoSomething(1, 2, 3)", 0, null, 0, null).GetParameterizeNamePart();
+
+            var result4 = CallerArgumentExpressionParser.GetParameterizedName("myInstance.DoSomething(1, 2, 3)");
             result4.ToString().Should().Be("DoSomething");
+        }
+        
+        [Fact]
+        public void GetParameterizeName_WithStringLiteral()
+        {
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName("Hoge.Moge(\"aaa.aaa(\"\"aaa\"\")\")");
+            result1.ToString().Should().Be("Moge");
+        }
+        
+        [Fact]
+        public void GetLastPropertyName_WithVerbatimStringLiteral()
+        {
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName("Hoge.Moge(@\"aaa.aaa(\\\"aaa\\\")\")");
+            result1.ToString().Should().Be("Moge");
+        }
+        
+        [Fact]
+        public void GetLastPropertyName_WithRawStringLiteral()
+        {
+            var result1 = CallerArgumentExpressionParser.GetParameterizedName(""""
+Hoge.Moge("""aaa...""bbb(((()))""..ccc""")
+"""");
+            result1.ToString().Should().Be("Moge");
+            
+            var result2 = CallerArgumentExpressionParser.GetParameterizedName("""""
+Hoge.Moge(""""
+aaa...
+bbb(((()))
+..ccc
+""""
+""""");
+            result2.ToString().Should().Be("Moge");
         }
     }
 }

--- a/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
+++ b/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
@@ -7,16 +7,16 @@ namespace ZLogger.Tests
         [Fact]
         public void GetLastPropertyName()
         {
-            var result1 = new InterpolatedStringParameter(typeof(int), "id", 0, null, 0, null).GetParameterizeName();
+            var result1 = new InterpolatedStringParameter(typeof(int), "id", 0, null, 0, null).GetParameterizeNamePart();
             result1.ToString().Should().Be("id");
             
-            var result2 = new InterpolatedStringParameter(typeof(int), "HttpContext.RequestId", 0, null, 0, null).GetParameterizeName();
+            var result2 = new InterpolatedStringParameter(typeof(int), "HttpContext.RequestId", 0, null, 0, null).GetParameterizeNamePart();
             result2.ToString().Should().Be("RequestId");
             
-            var result3 = new InterpolatedStringParameter(typeof(int), "MyNamespace.MyClass.Foo.Bar.Buz", 0, null, 0, null).GetParameterizeName();
+            var result3 = new InterpolatedStringParameter(typeof(int), "MyNamespace.MyClass.Foo.Bar.Buz", 0, null, 0, null).GetParameterizeNamePart();
             result3.ToString().Should().Be("Buz");
             
-            var result4 = new InterpolatedStringParameter(typeof(int), "myInstance.DoSomething(1, 2, 3)", 0, null, 0, null).GetParameterizeName();
+            var result4 = new InterpolatedStringParameter(typeof(int), "myInstance.DoSomething(1, 2, 3)", 0, null, 0, null).GetParameterizeNamePart();
             result4.ToString().Should().Be("DoSomething");
         }
     }

--- a/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
+++ b/tests/ZLogger.Tests/InterpolatedStringParameterTest.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+
+namespace ZLogger.Tests
+{
+    public class InterpolatedStringParameterTest
+    {
+        [Fact]
+        public void GetLastPropertyName()
+        {
+            var result1 = new InterpolatedStringParameter(typeof(int), "id", 0, null, 0, null).GetParameterizeName();
+            result1.ToString().Should().Be("id");
+            
+            var result2 = new InterpolatedStringParameter(typeof(int), "HttpContext.RequestId", 0, null, 0, null).GetParameterizeName();
+            result2.ToString().Should().Be("RequestId");
+            
+            var result3 = new InterpolatedStringParameter(typeof(int), "MyNamespace.MyClass.Foo.Bar.Buz", 0, null, 0, null).GetParameterizeName();
+            result3.ToString().Should().Be("Buz");
+            
+            var result4 = new InterpolatedStringParameter(typeof(int), "myInstance.DoSomething(1, 2, 3)", 0, null, 0, null).GetParameterizeName();
+            result4.ToString().Should().Be("DoSomething");
+        }
+    }
+}

--- a/tests/ZLogger.Tests/MessageTest.cs
+++ b/tests/ZLogger.Tests/MessageTest.cs
@@ -164,5 +164,38 @@ namespace ZLogger.Tests
             doc.GetProperty("LogLevel").GetString().Should().Be("Debug");
         }
 
+        [Fact]
+        public void KeyNameMutator_Lower()
+        {
+            var options = new ZLoggerOptions
+            {
+                IncludeScopes = true
+            };
+            options.UseJsonFormatter();
+            options.KeyNameMutator = KeyNameMutator.LowercaseInitial; 
+            
+            var processor = new TestProcessor(options);
+
+            using var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerLogProcessor(processor, options =>
+                {
+                    options.IncludeScopes = true;
+                });
+            });
+            var logger = loggerFactory.CreateLogger("test");
+
+            var Tako = 100;
+            var Yaki = "あいうえお";
+            logger.ZLogDebug($"tako: {Tako} yaki: {Yaki}");
+
+            var json = processor.Dequeue();
+            var doc = JsonDocument.Parse(json).RootElement;
+
+            doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
+            doc.GetProperty("tako").GetInt32().Should().Be(100);
+            doc.GetProperty("yaki").GetString().Should().Be("あいうえお");
+        }
     }
 }

--- a/tests/ZLogger.Tests/ZLogger.Tests.csproj
+++ b/tests/ZLogger.Tests/ZLogger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 


### PR DESCRIPTION
- Parse the string `[CallerExpressionArgument]`
    - Detect parameter names as follows:
         - `Context.RequestId` →  `RequestId`
         - `Collection.Count(....)` → `Count`
- Add a`KeyNameMutator` option to ZLoggerOptions.
   - Make it possible to mutate with the lower case.