### PR TITLE
Fix bugs for LogState

### DIFF
--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Buffers;
 using MessagePack;
 using Microsoft.Extensions.Logging;

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -26,6 +26,7 @@ namespace ZLogger.LogStates
 
             this.parameters = ArrayPool<InterpolatedStringParameter>.Shared.Rent(parameters.Length);
             parameters.CopyTo(this.parameters);
+            ParameterCount = parameters.Length;
 
             this.messageSequence = messageSequence;
             this.magicalBox = new MagicalBox(magicalBoxStorage, magicalBox.Written);
@@ -34,7 +35,7 @@ namespace ZLogger.LogStates
         public IZLoggerEntry CreateEntry(LogInfo info)
         {
             // state needs clone.
-            var newState = new InterpolatedStringLogState(messageSequence, this.magicalBox, this.parameters);
+            var newState = new InterpolatedStringLogState(messageSequence, this.magicalBox, this.parameters.AsSpan(0, ParameterCount));
 
             // Create Entry with cloned state(state will dispose when entry was disposed)
             return ZLoggerEntry<InterpolatedStringLogState>.Create(info, newState);
@@ -112,10 +113,7 @@ namespace ZLogger.LogStates
             {
                 return value;
             }
-            else
-            {
-                return (T?)p.BoxedValue;
-            }
+            return (T?)p.BoxedValue;
         }
 
         public Type GetParameterType(int index)

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.cs
@@ -22,6 +22,12 @@ public ref struct ZLoggerTraceInterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 [InterpolatedStringHandler]
@@ -41,6 +47,12 @@ public ref struct ZLoggerDebugInterpolatedStringHandler
     public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
+    }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 }
 
@@ -62,6 +74,12 @@ public ref struct ZLoggerInformationInterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 [InterpolatedStringHandler]
@@ -81,6 +99,12 @@ public ref struct ZLoggerWarningInterpolatedStringHandler
     public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
+    }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 }
 
@@ -102,6 +126,12 @@ public ref struct ZLoggerErrorInterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 [InterpolatedStringHandler]
@@ -121,6 +151,12 @@ public ref struct ZLoggerCriticalInterpolatedStringHandler
     public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
+    }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 }
 

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.tt
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.tt
@@ -32,6 +32,12 @@ public ref struct ZLogger<#= logLevel #>InterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 <# } #>


### PR DESCRIPTION
Fixed the following two minor issues:
- ParameterCount not being set in InterpolatedStringLogState
- Problem that `AppendFormatted<T>(Nullable<T> ...)` is not called