### PR TITLE
Add an option to easy set the output log infos

### DIFF
--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace ZLogger
 {
@@ -19,5 +18,5 @@ namespace ZLogger
             LogLevel = logLevel;
             Exception = exception;
         }
-  }
+    }
 }

--- a/src/ZLogger/ZLoggerOptions.cs
+++ b/src/ZLogger/ZLoggerOptions.cs
@@ -1,9 +1,19 @@
 using ZLogger.Formatters;
 using Microsoft.Extensions.Logging;
-using ZLogger.Formatters;
 
 namespace ZLogger
 {
+    [Flags]
+    public enum LogInfoProperties
+    {
+        Timestamp = 1 << 0,
+        LogLevel = 1 << 1,
+        CategoryName = 1 << 2,
+        EventIdValue = 1 << 3,
+        EventIdName = 1 << 4,
+        All = Timestamp | LogLevel | CategoryName | EventIdValue | EventIdName
+    }
+    
     public class ZLoggerOptions
     {
         public Action<LogInfo, Exception>? InternalErrorLogger { get; set; }
@@ -12,6 +22,7 @@ namespace ZLogger
         public bool IncludeScopes { get; set; }
         public IKeyNameMutator? KeyNameMutator { get; set; }
         public LogLevel LogToErrorThreshold { get; set; } = LogLevel.None;
+        public LogInfoProperties IncludeProperties { get; set; } = LogInfoProperties.All;
 
         Func<IZLoggerFormatter> formatterFactory = DefaultFormatterFactory;
 

--- a/tests/ZLogger.Tests/JsonFormatTest.cs
+++ b/tests/ZLogger.Tests/JsonFormatTest.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using ZLogger.Formatters;
+
+namespace ZLogger.Tests
+{
+    public class JsonFormatTest
+    {
+        [Fact]
+        public void FormatLogEntry_CustomMetadata()
+        {
+            using var ms = new MemoryStream();
+
+            var sourceCodeHash = Guid.NewGuid().ToString();
+
+
+            var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerStream(ms, option =>
+                {
+                    var hashProp = JsonEncodedText.Encode("Hash");
+
+                    option.UseJsonFormatter(formatter =>
+                    {
+                        formatter.MetadataFormatter = (writer, info, options) =>
+                        {
+                            // Use default and add custom metadata
+                            SystemTextJsonZLoggerFormatter.DefaultMetadataFormatter(writer, info, options);
+                            writer.WriteString(hashProp, sourceCodeHash);
+                        };
+                    });
+                });
+            });
+            var logger = loggerFactory.CreateLogger("test");
+
+            var tako = 100;
+            var yaki = "あいうえお";
+            logger.ZLogDebug($"FooBar{tako} NanoNano{yaki}");
+            
+            logger.LogInformation("");
+
+            loggerFactory.Dispose();
+
+            using var sr = new StreamReader(new MemoryStream(ms.ToArray()), Encoding.UTF8);
+            var json = sr.ReadLine();
+
+            var doc = JsonDocument.Parse(json).RootElement;
+
+            doc.GetProperty("Message").GetString().Should().Be("FooBar100 NanoNanoあいうえお");
+            doc.GetProperty("tako").GetInt32().Should().Be(100);
+            doc.GetProperty("yaki").GetString().Should().Be("あいうえお");
+
+            doc.GetProperty("Hash").GetString().Should().Be(sourceCodeHash);
+            doc.GetProperty("LogLevel").GetString().Should().Be("Debug");
+        }
+        
+        [Fact]
+        public void FormatLogEntry_ExcludeLogInfoProperties()
+        {
+            var options = new ZLoggerOptions
+            {
+                IncludeProperties = LogInfoProperties.LogLevel | 
+                                    LogInfoProperties.Timestamp |
+                                    LogInfoProperties.EventIdValue
+            }.UseJsonFormatter();
+
+            var processor = new TestProcessor(options);
+
+            var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerLogProcessor(processor);
+            });
+            var logger = loggerFactory.CreateLogger("test");
+            
+            var now = DateTime.UtcNow;
+            logger.ZLogInformation(new EventId(1, "TEST"), $"HELLO!");
+            
+            var json = processor.Dequeue();
+            var doc = JsonDocument.Parse(json).RootElement;
+
+            doc.GetProperty("Message").GetString().Should().Be("HELLO!");
+            doc.GetProperty("LogLevel").GetString().Should().Be("Information");
+            doc.GetProperty("Timestamp").GetDateTime().Should().BeOnOrAfter(now);
+            doc.GetProperty("EventId").GetInt32().Should().Be(1);
+            doc.TryGetProperty("EventIdName", out _).Should().BeFalse();
+            doc.TryGetProperty("CategoryName", out _).Should().BeFalse();
+        }
+        
+        [Fact]
+        public void KeyNameMutator_Lower()
+        {
+            var options = new ZLoggerOptions
+            {
+                IncludeScopes = true
+            };
+            options.UseJsonFormatter();
+            options.KeyNameMutator = KeyNameMutator.LowercaseInitial; 
+            
+            var processor = new TestProcessor(options);
+
+            using var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerLogProcessor(processor, options =>
+                {
+                    options.IncludeScopes = true;
+                });
+            });
+            var logger = loggerFactory.CreateLogger("test");
+
+            var Tako = 100;
+            var Yaki = "あいうえお";
+            logger.ZLogDebug($"tako: {Tako} yaki: {Yaki}");
+
+            var json = processor.Dequeue();
+            var doc = JsonDocument.Parse(json).RootElement;
+
+            doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
+            doc.GetProperty("tako").GetInt32().Should().Be(100);
+            doc.GetProperty("yaki").GetString().Should().Be("あいうえお");
+        }
+    }
+}

--- a/tests/ZLogger.Tests/PlainTextFormatTest.cs
+++ b/tests/ZLogger.Tests/PlainTextFormatTest.cs
@@ -1,16 +1,11 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using System;
-using System.IO;
-using System.Text;
-using System.Text.Json;
 using Utf8StringInterpolation;
-using Xunit;
-using ZLogger.Formatters;
 
 namespace ZLogger.Tests
 {
-    public class MessageTest
+    public class PlainTextFormatTest
     {
         [Fact]
         public void OverloadCheck()
@@ -113,89 +108,6 @@ namespace ZLogger.Tests
 
             logger.LogInformation("FooBar{0}-NanoNano{1}", 100, 300);
             processsor.Dequeue().Should().Be("[Pre:Information]FooBar100-NanoNano300[Suf:test]");
-        }
-
-        [Fact]
-        public void StructuredLoggingOptions()
-        {
-            using var ms = new MemoryStream();
-
-            var sourceCodeHash = Guid.NewGuid().ToString();
-
-
-            var loggerFactory = LoggerFactory.Create(x =>
-            {
-                x.SetMinimumLevel(LogLevel.Debug);
-                x.AddZLoggerStream(ms, option =>
-                {
-                    var hashProp = JsonEncodedText.Encode("Hash");
-
-                    option.UseJsonFormatter(formatter =>
-                    {
-                        formatter.MetadataFormatter = (writer, info) =>
-                        {
-                            // Use default and add custom metadata
-                            SystemTextJsonZLoggerFormatter.DefaultMetadataFormatter(writer, info);
-                            writer.WriteString(hashProp, sourceCodeHash);
-                        };
-                    });
-                });
-            });
-            var logger = loggerFactory.CreateLogger("test");
-
-            var tako = 100;
-            var yaki = "あいうえお";
-            logger.ZLogDebug($"FooBar{tako} NanoNano{yaki}");
-            
-            logger.LogInformation("");
-
-            loggerFactory.Dispose();
-
-            using var sr = new StreamReader(new MemoryStream(ms.ToArray()), Encoding.UTF8);
-            var json = sr.ReadLine();
-
-            var doc = JsonDocument.Parse(json).RootElement;
-
-            doc.GetProperty("Message").GetString().Should().Be("FooBar100 NanoNanoあいうえお");
-            doc.GetProperty("tako").GetInt32().Should().Be(100);
-            doc.GetProperty("yaki").GetString().Should().Be("あいうえお");
-
-            doc.GetProperty("Hash").GetString().Should().Be(sourceCodeHash);
-            doc.GetProperty("LogLevel").GetString().Should().Be("Debug");
-        }
-
-        [Fact]
-        public void KeyNameMutator_Lower()
-        {
-            var options = new ZLoggerOptions
-            {
-                IncludeScopes = true
-            };
-            options.UseJsonFormatter();
-            options.KeyNameMutator = KeyNameMutator.LowercaseInitial; 
-            
-            var processor = new TestProcessor(options);
-
-            using var loggerFactory = LoggerFactory.Create(x =>
-            {
-                x.SetMinimumLevel(LogLevel.Debug);
-                x.AddZLoggerLogProcessor(processor, options =>
-                {
-                    options.IncludeScopes = true;
-                });
-            });
-            var logger = loggerFactory.CreateLogger("test");
-
-            var Tako = 100;
-            var Yaki = "あいうえお";
-            logger.ZLogDebug($"tako: {Tako} yaki: {Yaki}");
-
-            var json = processor.Dequeue();
-            var doc = JsonDocument.Parse(json).RootElement;
-
-            doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
-            doc.GetProperty("tako").GetInt32().Should().Be(100);
-            doc.GetProperty("yaki").GetString().Should().Be("あいうえお");
         }
     }
 }


### PR DESCRIPTION
Make it easier selection of LogInfo properties to be render by flags.

```csharp
options.IncludeProperties = LogInfoProperties.LogLevel | 
                                                LogInfoProperties.Timestamp |
                                                LogInfoProperties.EventIdValue
```