### PR TITLE
Make the log state to manage by reference counting

### DIFF
--- a/sandbox/Benchmark/Benchmarks/WriteToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteToFile.cs
@@ -47,28 +47,5 @@ namespace Benchmark.Benchmarks
             var z = 30;
             ZLoggerLogger.ZLogInformation($"foo{x} bar{y} nazo{z}");
         }
-
-
-    }
-
-    internal struct FormatLogState<TPayload, T0, T1> : IZLoggerState
-    {
-        public readonly TPayload Payload;
-        public readonly string Format;
-        public readonly T0 Arg0;
-        public readonly T1 Arg1;
-
-        public FormatLogState(TPayload payload, string format, T0 arg0, T1 arg1)
-        {
-            Payload = payload;
-            Format = format;
-            Arg0 = arg0;
-            Arg1 = arg1;
-        }
-
-        public IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState)
-        {
-            return null;
-        }
     }
 }

--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Buffers;
 using MessagePack;
 using Microsoft.Extensions.Logging;

--- a/src/ZLogger/AsyncProcessZLogger.cs
+++ b/src/ZLogger/AsyncProcessZLogger.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using System;
 using ZLogger.LogStates;
 
 namespace ZLogger
@@ -30,6 +29,11 @@ namespace ZLogger
                 : new StringFormatterLogState<TState>(state, exception, formatter).CreateEntry(info); // standard `log`
 
             entry.ScopeState = scopeState;
+            
+            if (state is IReferenceCountZLoggerFormattable)
+            {
+                ((IReferenceCountZLoggerFormattable)state).Retain();
+            }
             logProcessor.Post(entry);
         }
 

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Text.Json;
 
 namespace ZLogger
@@ -21,5 +20,11 @@ namespace ZLogger
         object? GetParameterValue(int index);
         T? GetParameterValue<T>(int index);
         Type GetParameterType(int index);
+    }
+    
+    public interface IReferenceCountZLoggerFormattable : IZLoggerFormattable
+    {
+        void Retain();
+        void Release();
     }
 }

--- a/src/ZLogger/IZLoggerState.cs
+++ b/src/ZLogger/IZLoggerState.cs
@@ -1,7 +1,0 @@
-﻿namespace ZLogger
-{
-    public interface IZLoggerState
-    {
-        IZLoggerEntry CreateLogEntry(LogInfo logInfo, LogScopeState? scopeState);
-    }
-}

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -26,6 +26,7 @@ namespace ZLogger.LogStates
 
             this.parameters = ArrayPool<InterpolatedStringParameter>.Shared.Rent(parameters.Length);
             parameters.CopyTo(this.parameters);
+            ParameterCount = parameters.Length;
 
             this.messageSequence = messageSequence;
             this.magicalBox = new MagicalBox(magicalBoxStorage, magicalBox.Written);
@@ -34,7 +35,7 @@ namespace ZLogger.LogStates
         public IZLoggerEntry CreateEntry(LogInfo info)
         {
             // state needs clone.
-            var newState = new InterpolatedStringLogState(messageSequence, this.magicalBox, this.parameters);
+            var newState = new InterpolatedStringLogState(messageSequence, this.magicalBox, this.parameters.AsSpan(0, ParameterCount));
 
             // Create Entry with cloned state(state will dispose when entry was disposed)
             return ZLoggerEntry<InterpolatedStringLogState>.Create(info, newState);
@@ -112,10 +113,7 @@ namespace ZLogger.LogStates
             {
                 return value;
             }
-            else
-            {
-                return (T?)p.BoxedValue;
-            }
+            return (T?)p.BoxedValue;
         }
 
         public Type GetParameterType(int index)

--- a/src/ZLogger/LogStates/StringFormatterLogState.cs
+++ b/src/ZLogger/LogStates/StringFormatterLogState.cs
@@ -34,7 +34,6 @@ namespace ZLogger.LogStates
 
         public IZLoggerEntry CreateEntry(LogInfo info)
         {
-            // no need clone state.
             return ZLoggerEntry<StringFormatterLogState<TState>>.Create(info, this);
         }
 

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using ZLogger.Internal;
@@ -81,9 +80,9 @@ namespace ZLogger
 
         public void Return()
         {
-            if (state is IDisposable)
+            if (state is IReferenceCountZLoggerFormattable)
             {
-                ((IDisposable)state).Dispose();
+                ((IReferenceCountZLoggerFormattable)state).Release();
             }
 
             state = default!;

--- a/src/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger/ZLoggerExtensions.cs
@@ -24,8 +24,15 @@ namespace ZLogger
         {
             if (message.IsLoggerEnabled)
             {
-                using var state = message.GetStateAndClear();
-                logger.Log(logLevel, eventId, state, exception, static (state, ex) => state.ToString());
+                var state = message.GetStateAndClear();
+                try
+                {
+                    logger.Log(logLevel, eventId, state, exception, static (state, ex) => state.ToString());
+                }
+                finally
+                {
+                    state.Release();
+                }
             }
         }
 

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.cs
@@ -22,6 +22,12 @@ public ref struct ZLoggerTraceInterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 [InterpolatedStringHandler]
@@ -41,6 +47,12 @@ public ref struct ZLoggerDebugInterpolatedStringHandler
     public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
+    }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 }
 
@@ -62,6 +74,12 @@ public ref struct ZLoggerInformationInterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 [InterpolatedStringHandler]
@@ -81,6 +99,12 @@ public ref struct ZLoggerWarningInterpolatedStringHandler
     public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
+    }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 }
 
@@ -102,6 +126,12 @@ public ref struct ZLoggerErrorInterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 [InterpolatedStringHandler]
@@ -121,6 +151,12 @@ public ref struct ZLoggerCriticalInterpolatedStringHandler
     public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
+    }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 }
 

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.tt
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.tt
@@ -32,6 +32,12 @@ public ref struct ZLogger<#= logLevel #>InterpolatedStringHandler
     {
         this.innerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
+
+    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        where T : struct
+    {
+        this.innerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
+    }
 }
 
 <# } #>


### PR DESCRIPTION
This PR makes log state resource release a reference counting method as follows.

1. state is created. `+1`
2. (N times) each ZLogger provider posts to background worker. `+1`
3. (N times) each ZLogger provider finishes a i/o write. `-1`
4. After finishing the Logger.Log call (all Post calls should be finished). `-1`

