### PR TITLE
Support collection destructuring in the log message

### DIFF
--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -193,38 +193,14 @@ namespace ZLogger
                     ref var p = ref parameters[parameterIndex++];
                     if (!box.TryReadTo(p.Type, p.BoxOffset, p.Alignment, p.Format, ref stringWriter))
                     {
-                        switch (p.BoxedValue)
+                        if (p.BoxedValue is IEnumerable enumerable)
                         {
-                            case IList list:
-                            {
-                                for (var i = 0; i < list.Count; i++)
-                                {
-                                    if (i > 0)
-                                    {
-                                        stringWriter.AppendFormatted(", ");
-                                    }
-                                    stringWriter.AppendFormatted(list[i]);
-                                }
-                                break;
-                            }
-                            case IEnumerable enumerable:
-                            {
-                                var first = true;
-                                foreach (var obj in enumerable)
-                                {
-                                    if (!first)
-                                    {
-                                        stringWriter.AppendFormatted(", ");
-                                    }
-                                    stringWriter.AppendFormatted(obj);
-                                    first = false;
-                                }
-
-                                break;
-                            }
-                            default:
-                                stringWriter.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
-                                break;
+                            var jsonWriter = new Utf8JsonWriter(writer);
+                            JsonSerializer.Serialize(jsonWriter, enumerable);                            
+                        }
+                        else
+                        {
+                            stringWriter.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
                         }
                     }
                 }
@@ -248,37 +224,14 @@ namespace ZLogger
                     ref var p = ref parameters[parameterIndex++];
                     if (!box.TryReadTo(p.Type, p.BoxOffset, p.Alignment, p.Format, ref stringHandler))
                     {
-                        switch (p.BoxedValue)
+                        if (p.BoxedValue is IEnumerable enumerable)
                         {
-                            case IList list:
-                            {
-                                for (var i = 0; i < list.Count; i++)
-                                {
-                                    if (i > 0)
-                                    {
-                                        stringHandler.AppendFormatted(", ");
-                                    }
-                                    stringHandler.AppendFormatted(list[i]);
-                                }
-                                break;
-                            }
-                            case IEnumerable enumerable:
-                            {
-                                var first = false;
-                                foreach (var obj in enumerable)
-                                {
-                                    if (!first)
-                                    {
-                                        stringHandler.AppendFormatted(", ");
-                                    }
-                                    stringHandler.AppendFormatted(obj);
-                                }
-
-                                break;
-                            }
-                            default:
-                                stringHandler.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
-                                break;
+                            var jsonString = JsonSerializer.Serialize(enumerable);
+                            stringHandler.AppendFormatted(jsonString);
+                        }
+                        else
+                        {
+                            stringHandler.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
                         }
                     }
                 }

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System.Buffers;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -192,7 +193,39 @@ namespace ZLogger
                     ref var p = ref parameters[parameterIndex++];
                     if (!box.TryReadTo(p.Type, p.BoxOffset, p.Alignment, p.Format, ref stringWriter))
                     {
-                        stringWriter.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
+                        switch (p.BoxedValue)
+                        {
+                            case IList list:
+                            {
+                                for (var i = 0; i < list.Count; i++)
+                                {
+                                    if (i > 0)
+                                    {
+                                        stringWriter.AppendFormatted(", ");
+                                    }
+                                    stringWriter.AppendFormatted(list[i]);
+                                }
+                                break;
+                            }
+                            case IEnumerable enumerable:
+                            {
+                                var first = true;
+                                foreach (var obj in enumerable)
+                                {
+                                    if (!first)
+                                    {
+                                        stringWriter.AppendFormatted(", ");
+                                    }
+                                    stringWriter.AppendFormatted(obj);
+                                    first = false;
+                                }
+
+                                break;
+                            }
+                            default:
+                                stringWriter.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
+                                break;
+                        }
                     }
                 }
             }
@@ -215,7 +248,38 @@ namespace ZLogger
                     ref var p = ref parameters[parameterIndex++];
                     if (!box.TryReadTo(p.Type, p.BoxOffset, p.Alignment, p.Format, ref stringHandler))
                     {
-                        stringHandler.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
+                        switch (p.BoxedValue)
+                        {
+                            case IList list:
+                            {
+                                for (var i = 0; i < list.Count; i++)
+                                {
+                                    if (i > 0)
+                                    {
+                                        stringHandler.AppendFormatted(", ");
+                                    }
+                                    stringHandler.AppendFormatted(list[i]);
+                                }
+                                break;
+                            }
+                            case IEnumerable enumerable:
+                            {
+                                var first = false;
+                                foreach (var obj in enumerable)
+                                {
+                                    if (!first)
+                                    {
+                                        stringHandler.AppendFormatted(", ");
+                                    }
+                                    stringHandler.AppendFormatted(obj);
+                                }
+
+                                break;
+                            }
+                            default:
+                                stringHandler.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
+                                break;
+                        }
                     }
                 }
             }

--- a/tests/ZLogger.Tests/PlainTextFormatTest.cs
+++ b/tests/ZLogger.Tests/PlainTextFormatTest.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using System;
 using Utf8StringInterpolation;
+using System.Linq;
 
 namespace ZLogger.Tests
 {
@@ -108,6 +109,29 @@ namespace ZLogger.Tests
 
             logger.LogInformation("FooBar{0}-NanoNano{1}", 100, 300);
             processsor.Dequeue().Should().Be("[Pre:Information]FooBar100-NanoNano300[Suf:test]");
+        }
+        
+        [Fact]
+        public void CollectionDestructuring()
+        {
+            var options = new ZLoggerOptions();
+            options.UsePlainTextFormatter();
+            var processor = new TestProcessor(options);
+
+            var loggerFactory = LoggerFactory.Create(x =>
+            {
+                x.SetMinimumLevel(LogLevel.Debug);
+                x.AddZLoggerLogProcessor(processor);
+            });
+            var logger = loggerFactory.CreateLogger("test");
+
+            var array = new[] { 111, 222, 333 };
+            var enumerable = new[] { "a", "i", "u", "e" }.Where(_ => true);
+            
+            logger.ZLogDebug($"array: {array} enumerable: {enumerable}");
+
+            var message = processor.Dequeue();
+            message.Should().Be("array: 111, 222, 333 enumerable: a, i, u, e");
         }
     }
 }


### PR DESCRIPTION
For example:

```csharp
var array = new [] { 1,2,3 };
logger.ZLogInformation($"ids: {array}");

// #=> "ids: 1, 2, 3"
```