### PR TITLE
Fix benchmark settings

### DIFF
--- a/sandbox/Benchmark/Benchmarks/PostLogEntry.cs
+++ b/sandbox/Benchmark/Benchmarks/PostLogEntry.cs
@@ -7,7 +7,9 @@ using BenchmarkDotNet.Jobs;
 using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Extensions.Logging;
+using NLog.Targets.Wrappers;
 using Serilog;
+using Utf8StringInterpolation;
 using ZLogger;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -66,23 +68,33 @@ public class PostLogEntry
         
         var zLoggerFactory = LoggerFactory.Create(logging =>
         {
-            logging.AddZLoggerStream(Stream.Null);
+            logging.AddZLoggerStream(Stream.Null, options =>
+            {
+                options.UsePlainTextFormatter(formatter =>
+                {
+                    formatter.PrefixFormatter = (writer, info) =>
+                    {
+                        Utf8String.Format(writer, $"{info.Timestamp.DateTime} [{info.LogLevel}] ");
+                    };
+                });
+            });
         });
 
         zLogger = zLoggerFactory.CreateLogger<PostLogEntry>();
         
         // Microsoft.Extensions.Logging.Console
         
-        using var msExtLoggerFactory = LoggerFactory.Create(logging =>
+        var msExtConsoleLoggerFactory = LoggerFactory.Create(logging =>
         {
-            logging.AddConsole(options =>
-            {
-                // options.QueueFullMode = ConsoleLoggerQueueFullMode.DropWrite;
-                // options.MaxQueueLength = 1024;
-            });
+            logging
+                .AddConsole(options =>
+                {
+                    options.FormatterName = "BenchmarkPlainText";
+                })
+                .AddConsoleFormatter<BenchmarkPlainTextConsoleFormatter, BenchmarkPlainTextConsoleFormatter.Options>();
         });
 
-        msExtConsoleLogger = msExtLoggerFactory.CreateLogger<Program>();
+        msExtConsoleLogger = msExtConsoleLoggerFactory.CreateLogger<Program>();
         
         // Serilog
         
@@ -100,14 +112,18 @@ public class PostLogEntry
         serilogMsExtLogger = serilogMsExtLoggerFactory.CreateLogger<PostLogEntry>();
         
         // NLog
-
+        var nLogLayout = new NLog.Layouts.SimpleLayout("${longdate} [${level}] ${message}");
         {
             var nLogConfig = new NLog.Config.LoggingConfiguration(new LogFactory());
             var target = new NLog.Targets.FileTarget("Null")
             {
-                FileName = NullDevicePath
+                FileName = NullDevicePath,
+                Layout = nLogLayout
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, 10000, AsyncTargetWrapperOverflowAction.Grow)
+            {
+                TimeToSleepBetweenBatches = 0
+            };
             nLogConfig.AddTarget(asyncTarget);
             nLogConfig.AddRuleForAllLevels(asyncTarget);
             nLogConfig.LogFactory.Configuration = nLogConfig;
@@ -118,9 +134,13 @@ public class PostLogEntry
             var nLogConfigForMsExt = new NLog.Config.LoggingConfiguration(new LogFactory());
             var target = new NLog.Targets.FileTarget("Null")
             {
-                FileName = NullDevicePath
+                FileName = NullDevicePath,
+                Layout = nLogLayout
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, 10000, AsyncTargetWrapperOverflowAction.Grow)
+            {
+                TimeToSleepBetweenBatches = 0
+            };
             nLogConfigForMsExt.AddTarget(asyncTarget);
             nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget);
             nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;

--- a/sandbox/Benchmark/Benchmarks/WriteJsonToConsole.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteJsonToConsole.cs
@@ -79,11 +79,11 @@ public class WriteJsonToConsole
         var serilogFormatter = new JsonFormatter(renderMessage: true);
 
         serilogLogger = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: int.MaxValue)
+            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: N)
             .CreateLogger();
 
         serilogLoggerForMsExt = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: int.MaxValue)
+            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: N)
             .CreateLogger();
 
         serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt));
@@ -108,7 +108,10 @@ public class WriteJsonToConsole
             {
                 Layout = nLogLayout,
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, 10000, AsyncTargetWrapperOverflowAction.Grow)
+            {
+                TimeToSleepBetweenBatches = 0
+            };
             nLogConfig.AddTarget(asyncTarget);
             nLogConfig.AddRuleForAllLevels(asyncTarget);
             nLogConfig.LogFactory.Configuration = nLogConfig;
@@ -123,7 +126,10 @@ public class WriteJsonToConsole
                 {
                     Layout = nLogLayout
                 };
-                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
+                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, 10000, AsyncTargetWrapperOverflowAction.Grow)
+                {
+                    TimeToSleepBetweenBatches = 0
+                };
                 nLogConfigForMsExt.AddTarget(asyncTarget2);
                 nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget2);
                 nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;

--- a/sandbox/Benchmark/Benchmarks/WriteJsonToConsole.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteJsonToConsole.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
@@ -6,6 +7,7 @@ using BenchmarkDotNet.Jobs;
 using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Extensions.Logging;
+using NLog.Targets.Wrappers;
 using Serilog;
 using Serilog.Formatting.Json;
 using ZLogger;
@@ -28,7 +30,7 @@ file class BenchmarkConfig : ManualConfig
 public class WriteJsonToConsole
 {
     const int N = 100_000;
-    
+
     ILogger zLogger = default!;
     ILogger msExtConsoleLogger = default!;
     ILogger serilogMsExtLogger = default!;
@@ -41,7 +43,7 @@ public class WriteJsonToConsole
 
     Serilog.Core.Logger serilogLogger = default!;
     Serilog.Core.Logger serilogLoggerForMsExt = default!;
-    
+
     NLog.Logger nLogLogger = default!;
     NLog.Config.LoggingConfiguration nLogConfig = default!;
     NLog.Config.LoggingConfiguration nLogConfigForMsExt = default!;
@@ -50,9 +52,9 @@ public class WriteJsonToConsole
     public void SetUpLogger()
     {
         System.Console.SetOut(TextWriter.Null);
-        
+
         // ZLogger
-        
+
         zLoggerFactory = LoggerFactory.Create(logging =>
         {
             logging.AddZLoggerConsole(options =>
@@ -62,31 +64,31 @@ public class WriteJsonToConsole
         });
 
         zLogger = zLoggerFactory.CreateLogger<WritePlainTextToFile>();
-        
+
         // Microsoft.Extensions.Logging.Console
-        
+
         msExtConsoleLoggerFactory = LoggerFactory.Create(logging =>
         {
             logging.AddJsonConsole();
         });
 
         msExtConsoleLogger = msExtConsoleLoggerFactory.CreateLogger<WriteJsonToConsole>();
-        
+
         // Serilog
 
         var serilogFormatter = new JsonFormatter(renderMessage: true);
-        
+
         serilogLogger = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.Console(serilogFormatter))
+            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: int.MaxValue)
             .CreateLogger();
 
         serilogLoggerForMsExt = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.Console(serilogFormatter))
+            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: int.MaxValue)
             .CreateLogger();
-        
+
         serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt));
         serilogMsExtLogger = serilogMsExtLoggerFactory.CreateLogger<WriteJsonToConsole>();
-        
+
         // NLog
 
         var nLogLayout = new NLog.Layouts.JsonLayout
@@ -106,7 +108,7 @@ public class WriteJsonToConsole
             {
                 Layout = nLogLayout,
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
             nLogConfig.AddTarget(asyncTarget);
             nLogConfig.AddRuleForAllLevels(asyncTarget);
             nLogConfig.LogFactory.Configuration = nLogConfig;
@@ -121,7 +123,7 @@ public class WriteJsonToConsole
                 {
                     Layout = nLogLayout
                 };
-                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2);
+                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
                 nLogConfigForMsExt.AddTarget(asyncTarget2);
                 nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget2);
                 nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;
@@ -143,7 +145,7 @@ public class WriteJsonToConsole
         }
         zLoggerFactory.Dispose();
     }
-    
+
     [Benchmark]
     public void MsExtConsole_JsonConsole()
     {

--- a/sandbox/Benchmark/Benchmarks/WriteJsonToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteJsonToFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
@@ -6,6 +7,7 @@ using BenchmarkDotNet.Jobs;
 using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Extensions.Logging;
+using NLog.Targets.Wrappers;
 using Serilog;
 using Serilog.Formatting.Json;
 using ZLogger;
@@ -28,7 +30,7 @@ file class BenchmarkConfig : ManualConfig
 public class WriteJsonToFile
 {
     const int N = 100_000;
-    
+
     ILogger zLogger = default!;
     ILogger serilogMsExtLogger = default!;
     ILogger nLogMsExtLogger = default!;
@@ -39,12 +41,12 @@ public class WriteJsonToFile
 
     Serilog.Core.Logger serilogLogger = default!;
     Serilog.Core.Logger serilogLoggerForMsExt = default!;
-    
+
     NLog.Logger nLogLogger = default!;
     NLog.Config.LoggingConfiguration nLogConfig = default!;
     NLog.Config.LoggingConfiguration nLogConfigForMsExt = default!;
 
-    string tempDir = default!;
+    static string tempDir = default!;
 
     [GlobalSetup]
     public void SetUpDirectory()
@@ -67,7 +69,7 @@ public class WriteJsonToFile
     public void SetUpLogger()
     {
         // ZLogger
-        
+
         zLoggerFactory = LoggerFactory.Create(logging =>
         {
             logging.AddZLoggerFile(GetLogFilePath("zlogger.log"), options =>
@@ -77,22 +79,22 @@ public class WriteJsonToFile
         });
 
         zLogger = zLoggerFactory.CreateLogger<WritePlainTextToFile>();
-        
+
         // Serilog
 
         var serilogFormatter = new JsonFormatter(renderMessage: true);
-        
+
         serilogLogger = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog.log"), buffered: true))
+            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog.log"), buffered: true), bufferSize: int.MaxValue)
             .CreateLogger();
 
         serilogLoggerForMsExt = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog_msext.log"), buffered: true))
+            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog_msext.log"), buffered: true), bufferSize: int.MaxValue)
             .CreateLogger();
-        
-        serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt));
+
+        serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt, true));
         serilogMsExtLogger = serilogMsExtLoggerFactory.CreateLogger<WritePlainTextToFile>();
-        
+
         // NLog
 
         var nLogLayout = new NLog.Layouts.JsonLayout
@@ -113,7 +115,7 @@ public class WriteJsonToFile
                 FileName = GetLogFilePath("nlog.log"),
                 Layout = nLogLayout,
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
             nLogConfig.AddTarget(asyncTarget);
             nLogConfig.AddRuleForAllLevels(asyncTarget);
             nLogConfig.LogFactory.Configuration = nLogConfig;
@@ -129,7 +131,7 @@ public class WriteJsonToFile
                     FileName = GetLogFilePath("nlog_msext.log"),
                     Layout = nLogLayout
                 };
-                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2);
+                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
                 nLogConfigForMsExt.AddTarget(asyncTarget2);
                 nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget2);
                 nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;
@@ -181,6 +183,7 @@ public class WriteJsonToFile
         {
             nLogMsExtLogger.LogInformation("x={X} y={Y} z={Z}", 100, 200, 300);
         }
+        nLogConfigForMsExt.LogFactory.Shutdown();
         nLogMsExtLoggerFactory.Dispose();
     }
 
@@ -191,6 +194,7 @@ public class WriteJsonToFile
         {
             nLogLogger.Info("x={X} y={Y} z={Z}", 100, 200, 300);
         }
+        nLogConfig.LogFactory.Flush(TimeSpan.MaxValue);
         nLogConfig.LogFactory.Shutdown();
     }
 

--- a/sandbox/Benchmark/Benchmarks/WritePlainTextToConsole.cs
+++ b/sandbox/Benchmark/Benchmarks/WritePlainTextToConsole.cs
@@ -72,13 +72,17 @@ public class WritePlainTextToConsole
         zLogger = zLoggerFactory.CreateLogger<WritePlainTextToConsole>();
 
         // Microsoft.Extensions.Logging.Console
-
+        
         msExtConsoleLoggerFactory = LoggerFactory.Create(logging =>
         {
-            logging.AddJsonConsole();
+            logging
+                .AddConsole(options =>
+                {
+                    options.FormatterName = "BenchmarkPlainText";
+                })
+                .AddConsoleFormatter<BenchmarkPlainTextConsoleFormatter, BenchmarkPlainTextConsoleFormatter.Options>();
         });
-        msExtConsoleLogger = msExtConsoleLoggerFactory.CreateLogger<WritePlainTextToConsole>();
-
+        msExtConsoleLogger = msExtConsoleLoggerFactory.CreateLogger<Program>();
 
         // Serilog
 
@@ -122,7 +126,10 @@ public class WritePlainTextToConsole
                 {
                     Layout = nLogLayout
                 };
-                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, 10000, AsyncTargetWrapperOverflowAction.Grow);
+                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, 10000, AsyncTargetWrapperOverflowAction.Grow)
+                {
+                    TimeToSleepBetweenBatches = 0 
+                };
                 nLogConfigForMsExt.AddTarget(asyncTarget2);
                 nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget2);
                 nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;

--- a/sandbox/Benchmark/Benchmarks/WritePlainTextToConsole.cs
+++ b/sandbox/Benchmark/Benchmarks/WritePlainTextToConsole.cs
@@ -85,14 +85,14 @@ public class WritePlainTextToConsole
         var serilogFormatter = new MessageTemplateTextFormatter("{Timestamp} [{Level}] {Message}{NewLine}");
 
         serilogLogger = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: int.MaxValue)
+            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: N)
             .CreateLogger();
 
         serilogLoggerForMsExt = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: int.MaxValue)
+            .WriteTo.Async(a => a.Console(serilogFormatter), bufferSize: N)
             .CreateLogger();
 
-        serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt));
+        serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt, true));
         serilogMsExtLogger = serilogMsExtLoggerFactory.CreateLogger<WritePlainTextToConsole>();
 
         // NLog
@@ -104,7 +104,10 @@ public class WritePlainTextToConsole
             {
                 Layout = nLogLayout,
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, 10000, AsyncTargetWrapperOverflowAction.Grow)
+            {
+                TimeToSleepBetweenBatches = 0
+            };
             nLogConfig.AddTarget(asyncTarget);
             nLogConfig.AddRuleForAllLevels(asyncTarget);
             nLogConfig.LogFactory.Configuration = nLogConfig;
@@ -119,7 +122,7 @@ public class WritePlainTextToConsole
                 {
                     Layout = nLogLayout
                 };
-                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
+                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, 10000, AsyncTargetWrapperOverflowAction.Grow);
                 nLogConfigForMsExt.AddTarget(asyncTarget2);
                 nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget2);
                 nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;
@@ -181,6 +184,7 @@ public class WritePlainTextToConsole
         {
             nLogMsExtLogger.LogInformation("x={X} y={Y} z={Z}", 100, 200, 300);
         }
+        nLogConfigForMsExt.LogFactory.Shutdown();        
         nLogMsExtLoggerFactory.Dispose();
     }
 

--- a/sandbox/Benchmark/Benchmarks/WritePlainTextToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WritePlainTextToFile.cs
@@ -3,9 +3,11 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
+using Microsoft.Diagnostics.Runtime;
 using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Extensions.Logging;
+using NLog.Targets.Wrappers;
 using Serilog;
 using Serilog.Formatting.Display;
 using Utf8StringInterpolation;
@@ -28,7 +30,7 @@ file class BenchmarkConfig : ManualConfig
 public class WritePlainTextToFile
 {
     const int N = 100_000;
-    
+
     ILogger zLogger = default!;
     ILogger serilogMsExtLogger = default!;
     ILogger nLogMsExtLogger = default!;
@@ -39,7 +41,7 @@ public class WritePlainTextToFile
 
     Serilog.Core.Logger serilogLogger = default!;
     Serilog.Core.Logger serilogLoggerForMsExt = default!;
-    
+
     NLog.Logger nLogLogger = default!;
     NLog.Config.LoggingConfiguration nLogConfig = default!;
     NLog.Config.LoggingConfiguration nLogConfigForMsExt = default!;
@@ -67,7 +69,7 @@ public class WritePlainTextToFile
     public void SetUpLogger()
     {
         // ZLogger
-        
+
         zLoggerFactory = LoggerFactory.Create(logging =>
         {
             logging.AddZLoggerFile(GetLogFilePath("zlogger.log"), options =>
@@ -83,22 +85,22 @@ public class WritePlainTextToFile
         });
 
         zLogger = zLoggerFactory.CreateLogger<WritePlainTextToFile>();
-        
+
         // Serilog
 
         var serilogFormatter = new MessageTemplateTextFormatter("{Timestamp} [{Level}] {Message}{NewLine}");
-        
+
         serilogLogger = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog.log"), buffered: true))
+            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog.log"), buffered: true), bufferSize: int.MaxValue)
             .CreateLogger();
 
         serilogLoggerForMsExt = new Serilog.LoggerConfiguration()
-            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog_msext.log"), buffered: true))
+            .WriteTo.Async(a => a.File(serilogFormatter, GetLogFilePath("serilog_msext.log"), buffered: true), bufferSize: int.MaxValue)
             .CreateLogger();
-        
+
         serilogMsExtLoggerFactory = LoggerFactory.Create(logging => logging.AddSerilog(serilogLoggerForMsExt));
         serilogMsExtLogger = serilogMsExtLoggerFactory.CreateLogger<WritePlainTextToFile>();
-        
+
         // NLog
 
         var nLogLayout = new NLog.Layouts.SimpleLayout("${longdate} [${level}] ${message}");
@@ -109,7 +111,7 @@ public class WritePlainTextToFile
                 FileName = GetLogFilePath("nlog.log"),
                 Layout = nLogLayout,
             };
-            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target);
+            var asyncTarget = new NLog.Targets.Wrappers.AsyncTargetWrapper(target, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
             nLogConfig.AddTarget(asyncTarget);
             nLogConfig.AddRuleForAllLevels(asyncTarget);
 
@@ -125,7 +127,7 @@ public class WritePlainTextToFile
                     FileName = GetLogFilePath("nlog_msext.log"),
                     Layout = nLogLayout
                 };
-                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2);
+                var asyncTarget2 = new NLog.Targets.Wrappers.AsyncTargetWrapper(target2, int.MaxValue, AsyncTargetWrapperOverflowAction.Grow);
                 nLogConfigForMsExt.AddTarget(asyncTarget2);
                 nLogConfigForMsExt.AddRuleForAllLevels(asyncTarget2);
                 nLogConfigForMsExt.LogFactory.Configuration = nLogConfigForMsExt;
@@ -168,7 +170,7 @@ public class WritePlainTextToFile
         }
         serilogLogger.Dispose();
     }
-    
+
     [Benchmark]
     public void NLog_MsExt_PlainTextFile()
     {

--- a/sandbox/Benchmark/Formatters.cs
+++ b/sandbox/Benchmark/Formatters.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace Benchmark;
+
+class BenchmarkPlainTextConsoleFormatter : ConsoleFormatter
+{
+    internal class Options : ConsoleFormatterOptions
+    {
+    }
+    
+    public BenchmarkPlainTextConsoleFormatter() : base("BenchmarkPlainText")
+    {
+    }
+
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider scopeProvider, TextWriter textWriter)
+    {
+        var message = logEntry.Formatter.Invoke(logEntry.State, logEntry.Exception);
+        textWriter.Write(DateTime.Now);
+        textWriter.Write(" [");
+        textWriter.Write(logEntry.LogLevel);
+        textWriter.Write("] ");
+        textWriter.Write(message);
+    }
+}


### PR DESCRIPTION
Fix the settings of other libraries used for benchmarking. 
Also, make a few adjustments to ensure the same conditions as ZLogger.

## Problem with log messages dropping

- NLog
  - NLog's AsyncTargetWrapper ignores messages that exceed the queueLimit by default.
    - https://github.com/NLog/NLog/wiki/AsyncWrapper-target
  - -> `AsyncTargetWrapperOverflowAction`  set to `.Grow`.
  - -> `queueLimit` set to default (10000). 
- Serilog
    -  Serilog's BackgroundWorkerSink also drops messages that exceed the bufferSize.
    - -> `bufferSize` set to max value.
        - If bufferSize is exceeded, there are only two choices: drop or block the Log write side. Therefore, `blockWhenFull` is set to false (default) and bufferSize is increased.

## Other settings

- NLog
  - refs
    - AsyncTargetWrapper
      - https://github.com/NLog/NLog/wiki/AsyncWrapper-target
    - FileTarget
       - https://github.com/NLog/NLog/wiki/File-target
  - Seeping
      - By default, it seems to wait and batch writes for 1 ms.
        - -> `AsyncTargetWrapper.TimeToSleepBetweenBatches` set to 0 to match other loggers.
   - Flushing
      - -> `FileTarget.AutoFlash` is set to true
          - This is the same as ZLogger's behavior, and it flushes for each dequeued messages group.
        - -> `FileTarget.KeepFileOpen` set to true.
        - -> `FileTarget.ConcurrentWrites` set to false.
- Serilog
  - Flushing
     - If `buffered` is set to true, Serilog does not seem to do explicit flushes. This is probably not fair.
     - -> `flushToDiskInterval` set to 0.
       - First I tried setting `flushToDiskInterval` to 1 ms, but Serilog would hang..
