### PR TITLE
Use Cysharp/Actions/setup-dotnet default version

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -15,10 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
       # build CommandTools first (using dotnet run command in ZLogger.csproj)
       - run: dotnet build -c Debug ./tools/CommandTools/CommandTools.csproj
       - run: dotnet build -c Debug

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,10 +34,6 @@ jobs:
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
       # build CommandTools first (use dotnet run command in ZLogger.csproj)
       - run: dotnet build -c Release ./tools/CommandTools/CommandTools.csproj
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}


### PR DESCRIPTION
## tl;dr;

It support both .NET 6,7 and 8. No need specify version.

ZLogger already no need .NET 3.1