### PR TITLE
Add LogInfoProperties.None

### DIFF
--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -63,6 +63,7 @@ namespace ZLogger.MessagePack
 
         public MessagePackSerializerOptions MessagePackSerializerOptions { get; set; } = MessagePackSerializer.DefaultOptions;
         public string MessagePropertyName { get; set; } = "Message";
+        public LogInfoProperties IncludeProperties { get; set; } = LogInfoProperties.Timestamp | LogInfoProperties.LogLevel | LogInfoProperties.CategoryName;
 
         readonly ZLoggerOptions options;
 
@@ -74,9 +75,8 @@ namespace ZLogger.MessagePack
         public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
         {
             var messagePackWriter = new MessagePackWriter(writer);
-
-            var propCount = BitOperations.PopCount((uint)options.IncludeProperties) + entry.ParameterCount + 1;
-            if (entry.LogInfo.Exception != null)
+            var propCount = BitOperations.PopCount((uint)IncludeProperties) + entry.ParameterCount + 1;
+            if (entry.LogInfo.Exception != null) 
                 propCount++;
 
             if (entry.ScopeState != null)
@@ -93,27 +93,27 @@ namespace ZLogger.MessagePack
 
             messagePackWriter.WriteMapHeader(propCount);
 
-            if ((options.IncludeProperties & LogInfoProperties.CategoryName) != 0)
+            if ((IncludeProperties & LogInfoProperties.CategoryName) != 0)
             {
                 messagePackWriter.WriteRaw(CategoryNameKey);
                 messagePackWriter.WriteString(entry.LogInfo.Category.Utf8Span);
             }
-            if ((options.IncludeProperties & LogInfoProperties.LogLevel) != 0)
+            if ((IncludeProperties & LogInfoProperties.LogLevel) != 0)
             {
                 messagePackWriter.WriteRaw(LogLevelKey);
                 messagePackWriter.WriteRaw(EncodedLogLevel(entry.LogInfo.LogLevel));
             }
-            if ((options.IncludeProperties & LogInfoProperties.EventIdValue) != 0)
+            if ((IncludeProperties & LogInfoProperties.EventIdValue) != 0)
             {
                 messagePackWriter.WriteRaw(EventIdKey);
                 messagePackWriter.WriteInt32(entry.LogInfo.EventId.Id);
             }
-            if ((options.IncludeProperties & LogInfoProperties.EventIdName) != 0)
+            if ((IncludeProperties & LogInfoProperties.EventIdName) != 0)
             {
                 messagePackWriter.WriteRaw(EventIdNameKey);
                 messagePackWriter.Write(entry.LogInfo.EventId.Name);
             }
-            if ((options.IncludeProperties & LogInfoProperties.Timestamp) != 0)
+            if ((IncludeProperties & LogInfoProperties.Timestamp) != 0)
             {
                 messagePackWriter.WriteRaw(TimestampKey);
                 MessagePackSerializerOptions.Resolver.GetFormatterWithVerify<DateTime>()

--- a/src/ZLogger/ZLoggerOptions.cs
+++ b/src/ZLogger/ZLoggerOptions.cs
@@ -6,7 +6,7 @@ namespace ZLogger
     [Flags]
     public enum LogInfoProperties
     {
-        // TODO: needs None?
+        None = 0,
         Timestamp = 1 << 0,
         LogLevel = 1 << 1,
         CategoryName = 1 << 2,
@@ -25,7 +25,6 @@ namespace ZLogger
         public TimeSpan? FlushRate { get; set; }
         public IKeyNameMutator? KeyNameMutator { get; set; }
         public LogLevel LogToErrorThreshold { get; set; } = LogLevel.None;
-        public LogInfoProperties IncludeProperties { get; set; } = LogInfoProperties.Timestamp | LogInfoProperties.LogLevel | LogInfoProperties.CategoryName;
 
         Func<IZLoggerFormatter> formatterFactory = DefaultFormatterFactory;
 


### PR DESCRIPTION
For IncludeProperties in theoptions, `.None` was added because it was not possible to specify that nothing was to be logged.

In addition,
- this option is not useful in PlainTextFormatter, it has been moved to each formatter.