### PR TITLE
Move ScopeState into LogInfo

### DIFF
--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -89,9 +89,9 @@ namespace ZLogger.MessagePack
             if ((IncludeProperties & IncludeProperties.ScopeKeyValues) != 0)
             {
                 propCount--;
-                if (entry.ScopeState != null)
+                if (entry.LogInfo.ScopeState != null)
                 {
-                    var scopeProperties = entry.ScopeState.Properties;
+                    var scopeProperties = entry.LogInfo.ScopeState.Properties;
                     for (var i = 0; i < scopeProperties.Length; i++)
                     {
                         if (scopeProperties[i].Key != "{OriginalFormat}")
@@ -153,12 +153,11 @@ namespace ZLogger.MessagePack
             // Scope
             if ((flag & IncludeProperties.ScopeKeyValues) != 0)
             {
-                if (entry.ScopeState != null)
+                if (entry.LogInfo.ScopeState is { Properties: var scopeProperties })
                 {
-                    var scopeProperties = entry.ScopeState.Properties;
-                    for (var i = 0; i < scopeProperties.Length; i++)
+                    foreach (var t in scopeProperties)
                     {
-                        var (key, value) = scopeProperties[i];
+                        var (key, value) = t;
                         // If `BeginScope(format, arg1, arg2)` style is used, the first argument `format` string is passed with this name
                         if (key == "{OriginalFormat}") continue;
 

--- a/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
@@ -133,7 +133,7 @@ namespace ZLogger.Formatters
             // Scope
             if ((IncludeProperties & IncludeProperties.ScopeKeyValues) != 0)
             {
-                if (entry.ScopeState is { IsEmpty: false } scopeState)
+                if (entry.LogInfo.ScopeState is { IsEmpty: false } scopeState)
                 {
                     var properties = scopeState.Properties;
                     for (var i = 0; i < properties.Length; i++)

--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,22 +4,14 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public readonly struct LogInfo
+public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState)
 {
-    public readonly LogCategory Category;
-    public readonly Timestamp Timestamp;
-    public readonly LogLevel LogLevel;
-    public readonly EventId EventId;
-    public readonly Exception? Exception;
-
-    public LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception)
-    {
-        Category = category;
-        Timestamp = timestamp;
-        EventId = eventId;
-        LogLevel = logLevel;
-        Exception = exception;
-    }
+    public readonly LogCategory Category = category;
+    public readonly Timestamp Timestamp = timestamp;
+    public readonly LogLevel LogLevel = logLevel;
+    public readonly EventId EventId = eventId;
+    public readonly Exception? Exception = exception;
+    public readonly LogScopeState? ScopeState = scopeState;
 }
 
 public readonly struct LogCategory

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -1,5 +1,4 @@
 ﻿using System.Buffers;
-using System.Text;
 using System.Text.Json;
 using ZLogger.Internal;
 
@@ -9,7 +8,6 @@ namespace ZLogger
     public interface IZLoggerEntry : IZLoggerFormattable
     {
         LogInfo LogInfo { get; }
-        LogScopeState? ScopeState { get; set; }
         void FormatUtf8(IBufferWriter<byte> writer, IZLoggerFormatter formatter);
         void Return();
     }
@@ -18,8 +16,6 @@ namespace ZLogger
         where TState : IZLoggerFormattable
     {
         static readonly ObjectPool<ZLoggerEntry<TState>> cache = new();
-
-        public LogScopeState? ScopeState { get; set; }
 
         ZLoggerEntry<TState>? next;
         ref ZLoggerEntry<TState>? IObjectPoolNode<ZLoggerEntry<TState>>.NextNode => ref next;
@@ -80,11 +76,11 @@ namespace ZLogger
             {
                 ((IReferenceCountable)state).Release();
             }
-
             state = default!;
+
+            logInfo.ScopeState?.Return();
             logInfo = default!;
-            ScopeState?.Return();
-            ScopeState = default;
+            
             cache.TryPush(this);
         }
     }

--- a/src/ZLogger/ZLoggerLogger.cs
+++ b/src/ZLogger/ZLoggerLogger.cs
@@ -20,17 +20,15 @@ namespace ZLogger
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            var info = new LogInfo(category, new Timestamp(timeProvider), logLevel, eventId, exception);
-
             var scopeState = scopeProvider != null
                 ? LogScopeState.Create(scopeProvider)
                 : null;
+            
+            var info = new LogInfo(category, new Timestamp(timeProvider), logLevel, eventId, exception, scopeState);
 
             var entry = state is IZLoggerEntryCreatable
                 ? ((IZLoggerEntryCreatable)state).CreateEntry(info) // constrained call avoiding boxing for value types
                 : new StringFormatterLogState<TState>(state, exception, formatter).CreateEntry(info); // standard `log`
-
-            entry.ScopeState = scopeState;
 
             if (state is IReferenceCountable)
             {


### PR DESCRIPTION
Change `ZLoggerEntry.ScopeState` -> `ZLoggerEntry.LogInfo.ScopeState`

LogInfo can be handled by users through PrefixFormatter etc.