### PR TITLE
Add ZeroLog to benchmarks

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -19,6 +19,7 @@
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
 		<PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+		<PackageReference Include="ZeroLog" Version="2.1.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />


### PR DESCRIPTION
Hello,

I don't know if you've heard of [ZeroLog](https://github.com/Abc-Arbitrage/ZeroLog): it's a very similar library to ZLogger. Both projects aim to be fast and zero-allocation logging libraries.

I'm one of the authors of ZeroLog, so when I've seen your tweet about ZLogger v2, I was naturally interested in comparing both projects, so I added ZeroLog to your suite of benchmarks.

I thought you could be interested as well, so I'm sharing these here. 🙂

---

TL;DR:

- For file logging, ZeroLog sits between ZLogger's standard and source-generated APIs
- For console logging, ZeroLog seems very slow, I may need to take a look at this I suppose

Here's an example result of `WritePlainTextToFile`:

```
BenchmarkDotNet v0.13.10, Windows 11 (10.0.22631.2715/23H2/2023Update/SunValley3)
13th Gen Intel Core i9-13900K, 1 CPU, 32 logical and 24 physical cores
.NET SDK 8.0.100
  [Host]   : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

Job=ShortRun  InvocationCount=1  IterationCount=1
LaunchCount=1  UnrollFactor=1  WarmupCount=1

| Method                                      | Mean      | Error | recs/sec    | Gen0      | Gen1      | Gen2      | Allocated    |
|-------------------------------------------- |----------:|------:|------------:|----------:|----------:|----------:|-------------:|
| ZLogger_PlainTextFile                       |  79.98 ms |    NA | 1250296,946 |         - |         - |         - |   4899.09 KB |
| ZLogger_SourceGenerator_PlainTextFile       |  47.50 ms |    NA | 2105156,792 |         - |         - |         - |   4935.47 KB |
| ZeroLog_PlainTextFile                       |  63.30 ms |    NA | 1579731,414 |         - |         - |         - |     68.38 KB |
| Serilog_MsExt_PlainTextFile                 | 335.33 ms |    NA |  298211,388 | 6000.0000 | 1000.0000 |         - | 114032.21 KB |
| Serilog_MsExt_SourceGenerator_PlainTextFile | 354.80 ms |    NA |  281850,041 | 7000.0000 | 1000.0000 |         - | 141399.13 KB |
| Serilog_PlainTextFile                       |  78.06 ms |    NA | 1281141,343 | 4000.0000 | 3000.0000 | 1000.0000 |  58318.41 KB |
| Serilog_Default_MsExt_PlainTextFile         | 470.51 ms |    NA |  212534,882 | 6000.0000 | 1000.0000 |         - | 110942.87 KB |
| Serilog_Default_PlainTextFile               | 348.85 ms |    NA |  286659,689 | 3000.0000 | 1000.0000 |         - |  57085.81 KB |
| NLog_MsExt_PlainTextFile                    |  84.40 ms |    NA | 1184800,432 | 2000.0000 | 1000.0000 |         - |  55203.42 KB |
| NLog_MsExt_SourceGenerator_PlainTextFile    |  83.00 ms |    NA | 1204865,730 | 2000.0000 | 1000.0000 |         - |  54944.23 KB |
| NLog_PlainTextFile                          | 100.52 ms |    NA |  994836,797 | 3000.0000 | 3000.0000 | 1000.0000 |  53920.17 KB |
| NLog_Default_MsExt_PlainTextFile            | 195.06 ms |    NA |  512674,861 | 2000.0000 | 1000.0000 |         - |  54723.04 KB |
| NLog_Default_PlainTextFile                  | 186.08 ms |    NA |  537411,354 | 2000.0000 | 1000.0000 |         - |   39879.8 KB |
```

And finally, congrats for the v2 release of ZLogger and the great library perf. 👍
