### PR TITLE
Fix code generation by ZLoggerMessage

### DIFF
--- a/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -226,7 +226,7 @@ public partial class ZLoggerGenerator
             var modifiers = method.TargetSyntax.Modifiers.ToString();
             var extension = method.TargetMethod.IsExtensionMethod ? "this " : string.Empty;
 
-            var eventName = method.Attribute.EventName ?? $"nameof({method.TargetMethod.Name})";
+            var eventName = method.Attribute.EventName is { } name ? $"\"{name}\"" : $"nameof({method.TargetMethod.Name})";
 
             var loggerName = method.MethodParameters.First(x => x.IsFirstLogger).Symbol.Name;
 

--- a/tests/ZLogger.Generator.Tests/AttributeTest.cs
+++ b/tests/ZLogger.Generator.Tests/AttributeTest.cs
@@ -28,6 +28,9 @@ namespace ZLogger.Generator.Tests
         [ZLoggerMessage(LogLevel.Information, "Hello {x} {y}")]
         public partial void Err(ILogger logger, Exception exception, int x, int y);
 
+        [ZLoggerMessage(EventId = 12, EventName = "EventName", Level = LogLevel.Warning, Message = "Hello {x} {y}")]
+        public partial void EventName(ILogger logger, int x, int y);
+
 #pragma warning restore xUnit1013
 
         [Fact]
@@ -52,6 +55,9 @@ namespace ZLogger.Generator.Tests
 
             Three(logger, 30, 20);
             list[4].Should().Be("Warning:Hello 30 20");
+
+            EventName(logger, 40, 50);
+            list[5].Should().Be("Warning:Hello 40 50");
         }
 
         [Fact]


### PR DESCRIPTION
Fix error when EventName is passed to constructor of `ZLoggerMessageAttribute`.

before
```cs
public partial void EventName(global::Microsoft.Extensions.Logging.ILogger logger, int x, int y)
{
    if (!logger.IsEnabled(LogLevel.Warning)) return;
    logger.Log(
        LogLevel.Warning,
        new EventId(12, EventName), // <-- "EventName" is not string
        new EventNameState(x, y),
        null,
        (state, ex) => state.ToString()
    );
}
```

after
```cs
public partial void EventName(global::Microsoft.Extensions.Logging.ILogger logger, int x, int y)
{
    if (!logger.IsEnabled(LogLevel.Warning)) return;
    logger.Log(
        LogLevel.Warning,
        new EventId(12, "EventName"),
        new EventNameState(x, y),
        null,
        (state, ex) => state.ToString()
    );
}
```