### PR TITLE
Add nullable annotation to generated code

### DIFF
--- a/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -239,7 +239,12 @@ public partial class ZLoggerGenerator
             var stateTypeName = $"{method.TargetMethod.Name}State";
 
             var methodArgument = method.MethodParameters
-                .Select(x => $"{x.Symbol.Type.ToFullyQualifiedFormatString()} {x.Symbol.Name}")
+                .Select(x =>
+                {
+                    var t = x.Symbol.Type;
+                    var nullableSuffix = t.NullableAnnotation is NullableAnnotation.Annotated && t.IsValueType is false ? "?" : "";
+                    return $"{t.ToFullyQualifiedFormatString()}{nullableSuffix} {x.Symbol.Name}";
+                })
                 .StringJoinComma();
 
             var newParameters = methodParameters

--- a/tests/ZLogger.Generator.Tests/AttributeTest.cs
+++ b/tests/ZLogger.Generator.Tests/AttributeTest.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -27,6 +29,9 @@ namespace ZLogger.Generator.Tests
 
         [ZLoggerMessage(LogLevel.Information, "Hello {x} {y}")]
         public partial void Err(ILogger logger, Exception exception, int x, int y);
+
+        [ZLoggerMessage(LogLevel.Error, "Hello {str} {x}")]
+        public partial void ErrNullable(ILogger logger, string? str, int? x, Exception? exception = null);
 
 #pragma warning restore xUnit1013
 
@@ -59,7 +64,7 @@ namespace ZLogger.Generator.Tests
         {
             using var _ = TestHelper.CreateLogger<AttributeTest>(LogLevel.Debug, options => options.UsePlainTextFormatter(formatter =>
             {
-                formatter.SetPrefixFormatter($"{0}:", (template, info) => template.Format(info.Exception.Message));
+                formatter.SetPrefixFormatter($"{0}:", (template, info) => template.Format(info.Exception?.Message));
                 formatter.SetExceptionFormatter((_, _) => { });
             }), out var logger, out var list);
 


### PR DESCRIPTION
```cs
// Generation source
[ZLoggerMessage(LogLevel.Error, "Hello {str} {x}")]
public partial void ErrNullable(ILogger logger, string? str, int? x, Exception? exception = null);
```

before

![image](https://github.com/Cysharp/ZLogger/assets/230069/d8016991-ddba-41bc-abca-80b56a83bbdb)

after

![image](https://github.com/Cysharp/ZLogger/assets/230069/f77c9f57-4854-4f43-849c-b38f6762116f)

