### PR TITLE
Support caller informations

### DIFF
--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -37,12 +37,12 @@ public static partial class Log22
 
 }
 
-file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, IReadOnlyList<KeyValuePair<string, object?>>
+file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, ICallerTracable, IReadOnlyList<KeyValuePair<string, object?>>
 {
     static readonly JsonEncodedText _jsonParameter_hostName = JsonEncodedText.Encode("hostName");
     static readonly JsonEncodedText _jsonParameter_ipAddress = JsonEncodedText.Encode("ipAddress");
 
-    public int CallerLineNumber { get; }
+    public LogCallerInfo? CallerInfo { get; }
 
     readonly string hostName;
     readonly int ipAddress;
@@ -51,7 +51,6 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, IReadOnlyLis
     {
         this.hostName = hostName;
         this.ipAddress = ipAddress;
-        CallerLineNumber = callerLineNumber;
     }
 
     public IZLoggerEntry CreateEntry(in LogInfo info)

--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -50,7 +50,7 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, IReadOnlyLis
         this.ipAddress = ipAddress;
     }
 
-    public IZLoggerEntry CreateEntry(LogInfo info)
+    public IZLoggerEntry CreateEntry(in LogInfo info)
     {
         return ZLoggerEntry<CouldNotOpenSocketState>.Create(info, this);
     }
@@ -197,7 +197,7 @@ file readonly struct SamplerState2 : IZLoggerFormattable
         this.dt = dt;
     }
 
-    public IZLoggerEntry CreateEntry(LogInfo info)
+    public IZLoggerEntry CreateEntry(in LogInfo info)
     {
         return ZLoggerEntry<SamplerState2>.Create(info, this);
     }

--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -42,7 +42,9 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, ICallerTraca
     static readonly JsonEncodedText _jsonParameter_hostName = JsonEncodedText.Encode("hostName");
     static readonly JsonEncodedText _jsonParameter_ipAddress = JsonEncodedText.Encode("ipAddress");
 
-    public LogCallerInfo? CallerInfo { get; }
+    public string? CallerMemberName { get; }
+    public string? CallerFilePath { get; }
+    public int CallerLineNumber { get; }
 
     readonly string hostName;
     readonly int ipAddress;
@@ -51,6 +53,7 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, ICallerTraca
     {
         this.hostName = hostName;
         this.ipAddress = ipAddress;
+        CallerLineNumber = callerLineNumber;
     }
 
     public IZLoggerEntry CreateEntry(in LogInfo info)

--- a/sandbox/GeneratorSandbox/GeneratedMock.cs
+++ b/sandbox/GeneratorSandbox/GeneratedMock.cs
@@ -26,13 +26,14 @@ public static partial class Log22
         logger.Log(LogLevel.Information, -1, new CouldNotOpenSocketState(hostName, ipAddress), exception, (state, ex) => state.ToString());
     }
 
-
+    public static void CouldNotOpenSocketWithCaller(this ILogger<FooBarBaz> logger, string hostName, int ipAddress, [CallerLineNumber] int lineNumber = 0)
+    {
+        if (!logger.IsEnabled(LogLevel.Information)) return;
+        logger.Log(LogLevel.Information, -1, new CouldNotOpenSocketState(hostName, ipAddress, lineNumber), null, (state, ex) => state.ToString());
+    }
 
     [ZLoggerMessage(LogLevel.Information, "Could not open socket to {hostName} {ipAddress}.")]
     public static partial void CouldNotOpenSocket3(this ILogger<FooBarBaz> logger, string hostName, int ipAddress);
-
-
-
 
 }
 
@@ -41,13 +42,16 @@ file readonly struct CouldNotOpenSocketState : IZLoggerFormattable, IReadOnlyLis
     static readonly JsonEncodedText _jsonParameter_hostName = JsonEncodedText.Encode("hostName");
     static readonly JsonEncodedText _jsonParameter_ipAddress = JsonEncodedText.Encode("ipAddress");
 
+    public int CallerLineNumber { get; }
+
     readonly string hostName;
     readonly int ipAddress;
 
-    public CouldNotOpenSocketState(string hostName, int ipAddress)
+    public CouldNotOpenSocketState(string hostName, int ipAddress, int callerLineNumber = 0)
     {
         this.hostName = hostName;
         this.ipAddress = ipAddress;
+        CallerLineNumber = callerLineNumber;
     }
 
     public IZLoggerEntry CreateEntry(in LogInfo info)

--- a/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -74,7 +74,9 @@ public partial class ZLoggerGenerator
             sb.AppendLine($$"""
     readonly struct {{stateTypeName}} : IZLoggerFormattable, ICallerTracable, IReadOnlyList<KeyValuePair<string, object?>>
     {
-        public LogCallerInfo? CallerInfo { get; } 
+        public string? CallerMemberName { get; }
+        public string? CallerFilePath { get; }
+        public int CallerLineNumber { get; }
     
 {{jsonParameters}}
 
@@ -86,12 +88,24 @@ public partial class ZLoggerGenerator
 """);
             if (callerInfoParameters.Length > 0)
             {
-                var callerMemberNameArg = callerInfoParameters.FirstOrDefault(x => x.IsCallerMemberName)?.Symbol.Name ?? "null";
-                var callerFilePathArg = callerInfoParameters.FirstOrDefault(x => x.IsCallerFilePath)?.Symbol.Name ?? "null";
-                var callerLineNumberArg = callerInfoParameters.FirstOrDefault(x => x.IsCallerLineNumber)?.Symbol.Name ?? "default";
-                sb.AppendLine($$"""
-                    CallerInfo = new LogCallerInfo({{callerMemberNameArg}}, {{callerFilePathArg}}, {{callerLineNumberArg}});
+                if (callerInfoParameters.FirstOrDefault(x => x.IsCallerMemberName) is { } callerMemberNameArg)
+                {
+                    sb.AppendLine($$"""
+            CallerMemberName = {{callerMemberNameArg.Symbol.Name}};
 """);
+                }
+                if (callerInfoParameters.FirstOrDefault(x => x.IsCallerFilePath) is { } callerFilePathArg)
+                {
+                    sb.AppendLine($$"""
+            CallerFilePath = {{callerFilePathArg.Symbol.Name}};
+""");
+                }
+                if (callerInfoParameters.FirstOrDefault(x => x.IsCallerLineNumber) is { } callerLineNumberArg)
+                {
+                    sb.AppendLine($$"""
+            CallerLineNumber = {{callerLineNumberArg.Symbol.Name}};
+""");
+                }
             }
             sb.AppendLine($$"""
         }

--- a/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -59,7 +59,11 @@ public partial class ZLoggerGenerator
                 .StringJoinNewLine();
 
             var fieldParameters = methodParameters
-                .Select(x => $"        readonly {x.Symbol.Type.ToFullyQualifiedFormatString()} {x.LinkedMessageSegment.NameParameter};")
+                .Select(x =>
+                {
+                    if (x.IsCallerFilePath)
+                    return $"        readonly {x.Symbol.Type.ToFullyQualifiedFormatString()} {x.LinkedMessageSegment.NameParameter};";
+                })
                 .StringJoinNewLine();
 
             var constructorParameters = methodParameters
@@ -71,7 +75,7 @@ public partial class ZLoggerGenerator
                 .StringJoinNewLine();
 
             sb.AppendLine($$"""
-    readonly struct {{stateTypeName}} : IZLoggerFormattable, IReadOnlyList<KeyValuePair<string, object?>>
+    readonly struct {{stateTypeName}} : IZLoggerFormattable, ICallerInfo, IReadOnlyList<KeyValuePair<string, object?>>
     {
 {{jsonParameters}}
 

--- a/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
+++ b/src/ZLogger.Generator/ZLoggerGenerator.Emitter.cs
@@ -82,7 +82,7 @@ public partial class ZLoggerGenerator
 {{constructorBody}}
         }
 
-        public IZLoggerEntry CreateEntry(LogInfo info)
+        public IZLoggerEntry CreateEntry(in LogInfo info)
         {
             return ZLoggerEntry<{{stateTypeName}}>.Create(info, this);
         }

--- a/src/ZLogger.Generator/ZLoggerGenerator.Parser.cs
+++ b/src/ZLogger.Generator/ZLoggerGenerator.Parser.cs
@@ -29,7 +29,7 @@ public partial class ZLoggerGenerator
         public bool IsCallerFilePath { get; init; }
         public bool IsCallerLineNumber { get; init; }
 
-        public bool IsParameter => !IsFirstLogger && !IsFirstLogLevel && !IsFirstException;
+        public bool IsParameter => !IsFirstLogger && !IsFirstLogLevel && !IsFirstException && !IsCallerInfo;
         public bool IsCallerInfo => IsCallerMemberName || IsCallerFilePath || IsCallerLineNumber;
 
         // set from outside, if many segments was linked, use first-one.
@@ -71,9 +71,9 @@ public partial class ZLoggerGenerator
             this.loggerSymbol = GetTypeByMetadataName(compilation, "Microsoft.Extensions.Logging.ILogger");
             this.logLevelSymbol = GetTypeByMetadataName(compilation, "Microsoft.Extensions.Logging.LogLevel");
             this.exceptionSymbol = GetTypeByMetadataName(compilation, "System.Exception");
-            this.callerMemberNameAttributeSymbol = GetTypeByMetadataName(compilation, "System.Runtime.CompilerServices.CallerMemberName");
-            this.callerFilePathAttributeSymbol = GetTypeByMetadataName(compilation, "System.Runtime.CompilerServices.CallerFilePath");
-            this.callerLineNumberAttributeSymbol = GetTypeByMetadataName(compilation, "System.Runtime.CompilerServices.CallerLineNumber");
+            this.callerMemberNameAttributeSymbol = GetTypeByMetadataName(compilation, "System.Runtime.CompilerServices.CallerMemberNameAttribute");
+            this.callerFilePathAttributeSymbol = GetTypeByMetadataName(compilation, "System.Runtime.CompilerServices.CallerFilePathAttribute");
+            this.callerLineNumberAttributeSymbol = GetTypeByMetadataName(compilation, "System.Runtime.CompilerServices.CallerLineNumberAttribute");
         }
 
         static INamedTypeSymbol GetTypeByMetadataName(Compilation compilation, string metadataName)

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -35,5 +35,7 @@ public interface IReferenceCountable
 
 public interface ICallerTracable
 {
-    LogCallerInfo? CallerInfo { get; }
+    string? CallerMemberName { get; }
+    string? CallerFilePath { get; }
+    int CallerLineNumber { get; }
 }

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -33,4 +33,11 @@ namespace ZLogger
         void Retain();
         void Release();
     }
+
+    public interface ICallerInfo
+    {
+        string? CallerMemberName { get; }
+        string? CallerFilePath { get; }
+        int CallerLineNumber { get; }
+    }
 }

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -1,43 +1,39 @@
 ﻿using System.Buffers;
 using System.Text.Json;
 
-namespace ZLogger
+namespace ZLogger;
+// Implement for log state.
+
+public interface IZLoggerEntryCreatable
 {
-    // Implement for log state.
+    IZLoggerEntry CreateEntry(in LogInfo info);
+}
 
-    public interface IZLoggerEntryCreatable
-    {
-        IZLoggerEntry CreateEntry(in LogInfo info);
-    }
+public interface IZLoggerFormattable : IZLoggerEntryCreatable
+{
+    int ParameterCount { get; }
+    bool IsSupportUtf8ParameterKey { get; }
+    string ToString();
+    void ToString(IBufferWriter<byte> writer);
 
-    public interface IZLoggerFormattable : IZLoggerEntryCreatable
-    {
-        int ParameterCount { get; }
-        bool IsSupportUtf8ParameterKey { get; }
-        string ToString();
-        void ToString(IBufferWriter<byte> writer);
+    void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, IKeyNameMutator? keyNameMutator = null);
 
-        void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, IKeyNameMutator? keyNameMutator = null);
+    ReadOnlySpan<byte> GetParameterKey(int index);
+    string GetParameterKeyAsString(int index);
+    object? GetParameterValue(int index);
+    T? GetParameterValue<T>(int index);
+    Type GetParameterType(int index);
 
-        ReadOnlySpan<byte> GetParameterKey(int index);
-        string GetParameterKeyAsString(int index);
-        object? GetParameterValue(int index);
-        T? GetParameterValue<T>(int index);
-        Type GetParameterType(int index);
+    object? GetContext();
+}
 
-        object? GetContext();
-    }
+public interface IReferenceCountable
+{
+    void Retain();
+    void Release();
+}
 
-    public interface IReferenceCountable
-    {
-        void Retain();
-        void Release();
-    }
-
-    public interface ICallerInfo
-    {
-        string? CallerMemberName { get; }
-        string? CallerFilePath { get; }
-        int CallerLineNumber { get; }
-    }
+public interface ICallerTracable
+{
+    LogCallerInfo? CallerInfo { get; }
 }

--- a/src/ZLogger/IZLoggerFormattable.cs
+++ b/src/ZLogger/IZLoggerFormattable.cs
@@ -7,7 +7,7 @@ namespace ZLogger
 
     public interface IZLoggerEntryCreatable
     {
-        IZLoggerEntry CreateEntry(LogInfo info);
+        IZLoggerEntry CreateEntry(in LogInfo info);
     }
 
     public interface IZLoggerFormattable : IZLoggerEntryCreatable

--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, in LogCallerInfo? callerInfo = default)
+public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, string? callerMemberName = null, string? callerFilePath = null, int callerLineNumber = 0)
 {
     public readonly LogCategory Category = category;
     public readonly Timestamp Timestamp = timestamp;
@@ -12,7 +12,9 @@ public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLev
     public readonly EventId EventId = eventId;
     public readonly Exception? Exception = exception;
     public readonly LogScopeState? ScopeState = scopeState;
-    public readonly LogCallerInfo? CallerInfo = callerInfo;
+    public readonly string? CallerMemberName = callerMemberName;
+    public readonly string? CallerFilePath = callerFilePath;
+    public readonly int CallerLineNumber = callerLineNumber;
 }
 
 public readonly struct LogCategory
@@ -34,11 +36,4 @@ public readonly struct LogCategory
     {
         return Name;
     }
-}
-
-public readonly struct LogCallerInfo(string? memberName, string? filePath, int lineNumber)
-{
-    public readonly string? MemberName = memberName;
-    public readonly string? FilePath = filePath;
-    public readonly int LineNumber = lineNumber;
 }

--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, in LogCallerInfo? callerInfo)
+public struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState)
 {
     public readonly LogCategory Category = category;
     public readonly Timestamp Timestamp = timestamp;
@@ -12,14 +12,9 @@ public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLev
     public readonly EventId EventId = eventId;
     public readonly Exception? Exception = exception;
     public readonly LogScopeState? ScopeState = scopeState;
-    public readonly LogCallerInfo? CallerInfo = callerInfo;
-}
-
-public readonly struct LogCallerInfo(string memberName, string filePath, int lineNumber)
-{
-    public readonly string MemberName = memberName;
-    public readonly string FilePath = filePath;
-    public readonly int LineNumber = lineNumber;
+    public string? CallerMemberName;
+    public string? CallerFileName;
+    public int CallerLineNumber;
 }
 
 public readonly struct LogCategory

--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState)
+public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, in LogCallerInfo? callerInfo = default)
 {
     public readonly LogCategory Category = category;
     public readonly Timestamp Timestamp = timestamp;
@@ -12,9 +12,7 @@ public struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLev
     public readonly EventId EventId = eventId;
     public readonly Exception? Exception = exception;
     public readonly LogScopeState? ScopeState = scopeState;
-    public string? CallerMemberName;
-    public string? CallerFileName;
-    public int CallerLineNumber;
+    public readonly LogCallerInfo? CallerInfo = callerInfo;
 }
 
 public readonly struct LogCategory
@@ -36,4 +34,11 @@ public readonly struct LogCategory
     {
         return Name;
     }
+}
+
+public readonly struct LogCallerInfo(string? memberName, string? filePath, int lineNumber)
+{
+    public readonly string? MemberName = memberName;
+    public readonly string? FilePath = filePath;
+    public readonly int LineNumber = lineNumber;
 }

--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState)
+public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, in LogCallerInfo? callerInfo)
 {
     public readonly LogCategory Category = category;
     public readonly Timestamp Timestamp = timestamp;
@@ -12,6 +12,14 @@ public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLev
     public readonly EventId EventId = eventId;
     public readonly Exception? Exception = exception;
     public readonly LogScopeState? ScopeState = scopeState;
+    public readonly LogCallerInfo? CallerInfo = callerInfo;
+}
+
+public readonly struct LogCallerInfo(string memberName, string filePath, int lineNumber)
+{
+    public readonly string MemberName = memberName;
+    public readonly string FilePath = filePath;
+    public readonly int LineNumber = lineNumber;
 }
 
 public readonly struct LogCategory

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -10,6 +10,7 @@ namespace ZLogger.LogStates;
 public sealed class InterpolatedStringLogState : 
     IZLoggerFormattable, 
     IReferenceCountable, 
+    ICallerInfo,
     IObjectPoolNode<InterpolatedStringLogState>, 
     IEnumerable<KeyValuePair<string, object?>>
 {
@@ -18,9 +19,11 @@ public sealed class InterpolatedStringLogState :
     public ref InterpolatedStringLogState? NextNode => ref next;
     InterpolatedStringLogState? next;
 
-    public int ParameterCount { get; private set; }
-    public LogCallerInfo? CallerInfo { get; set; }
     public bool IsSupportUtf8ParameterKey => false;
+    public int ParameterCount { get; private set; }
+    public string? CallerMemberName { get; set; }
+    public string? CallerFilePath { get; set; }
+    public int CallerLineNumber { get; set; }
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => new Enumerator(this);
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -58,7 +61,9 @@ public sealed class InterpolatedStringLogState :
         }
         state.ParameterCount = formattedCount;
         state.refCount = 1;
-        state.CallerInfo = default;
+        state.CallerMemberName = default!;
+        state.CallerFilePath = default!;
+        state.CallerLineNumber = default;
 
         return state;
     }

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -19,6 +19,7 @@ public sealed class InterpolatedStringLogState :
     InterpolatedStringLogState? next;
 
     public int ParameterCount { get; private set; }
+    public LogCallerInfo? CallerInfo { get; set; }
     public bool IsSupportUtf8ParameterKey => false;
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => new Enumerator(this);
@@ -57,13 +58,14 @@ public sealed class InterpolatedStringLogState :
         }
         state.ParameterCount = formattedCount;
         state.refCount = 1;
+        state.CallerInfo = default;
 
         return state;
     }
 
-    public IZLoggerEntry CreateEntry(LogInfo info)
+    public IZLoggerEntry CreateEntry(in LogInfo info)
     {
-        return ZLoggerEntry<InterpolatedStringLogState>.Create(info, this);
+        return ZLoggerEntry<InterpolatedStringLogState>.Create(in info, this);
     }
 
     public void Retain()
@@ -185,6 +187,7 @@ public readonly struct VersionedLogState : IZLoggerEntryCreatable, IReferenceCou
     readonly InterpolatedStringLogState state;
     readonly int version;
 
+    public LogCallerInfo? CallerInfo => state.CallerInfo;
     public int Version => version;
 
     internal VersionedLogState(InterpolatedStringLogState state)
@@ -193,7 +196,7 @@ public readonly struct VersionedLogState : IZLoggerEntryCreatable, IReferenceCou
         this.version = state.Version;
     }
 
-    public IZLoggerEntry CreateEntry(LogInfo info)
+    public IZLoggerEntry CreateEntry(in LogInfo info)
     {
         return state.CreateEntry(info);
     }

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -21,7 +21,9 @@ public sealed class InterpolatedStringLogState :
 
     public bool IsSupportUtf8ParameterKey => false;
     public int ParameterCount { get; private set; }
-    public LogCallerInfo? CallerInfo { get; set; }
+    public string? CallerMemberName { get; set; }
+    public string? CallerFilePath { get; set; }
+    public int CallerLineNumber { get; set; }
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => new Enumerator(this);
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -59,7 +61,9 @@ public sealed class InterpolatedStringLogState :
         }
         state.ParameterCount = formattedCount;
         state.refCount = 1;
-        state.CallerInfo = default;
+        state.CallerMemberName = default;
+        state.CallerFilePath = default;
+        state.CallerLineNumber = default;
         return state;
     }
 
@@ -188,7 +192,10 @@ public readonly struct VersionedLogState : IZLoggerEntryCreatable, IReferenceCou
     readonly int version;
 
     public int Version => version;
-    public LogCallerInfo? CallerInfo => state.CallerInfo;
+
+    public string? CallerMemberName => state.CallerMemberName;
+    public string? CallerFilePath => state.CallerFilePath;
+    public int CallerLineNumber => state.CallerLineNumber;
 
     internal VersionedLogState(InterpolatedStringLogState state)
     {

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -9,8 +9,8 @@ namespace ZLogger.LogStates;
 
 public sealed class InterpolatedStringLogState : 
     IZLoggerFormattable, 
-    IReferenceCountable, 
-    ICallerInfo,
+    IReferenceCountable,
+    ICallerTracable,
     IObjectPoolNode<InterpolatedStringLogState>, 
     IEnumerable<KeyValuePair<string, object?>>
 {
@@ -21,9 +21,7 @@ public sealed class InterpolatedStringLogState :
 
     public bool IsSupportUtf8ParameterKey => false;
     public int ParameterCount { get; private set; }
-    public string? CallerMemberName { get; set; }
-    public string? CallerFilePath { get; set; }
-    public int CallerLineNumber { get; set; }
+    public LogCallerInfo? CallerInfo { get; set; }
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => new Enumerator(this);
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -61,10 +59,7 @@ public sealed class InterpolatedStringLogState :
         }
         state.ParameterCount = formattedCount;
         state.refCount = 1;
-        state.CallerMemberName = default!;
-        state.CallerFilePath = default!;
-        state.CallerLineNumber = default;
-
+        state.CallerInfo = default;
         return state;
     }
 
@@ -187,13 +182,13 @@ public sealed class InterpolatedStringLogState :
 }
 
 [StructLayout(LayoutKind.Auto)]
-public readonly struct VersionedLogState : IZLoggerEntryCreatable, IReferenceCountable, IEnumerable<KeyValuePair<string, object?>>
+public readonly struct VersionedLogState : IZLoggerEntryCreatable, IReferenceCountable, ICallerTracable, IEnumerable<KeyValuePair<string, object?>>
 {
     readonly InterpolatedStringLogState state;
     readonly int version;
 
-    public LogCallerInfo? CallerInfo => state.CallerInfo;
     public int Version => version;
+    public LogCallerInfo? CallerInfo => state.CallerInfo;
 
     internal VersionedLogState(InterpolatedStringLogState state)
     {

--- a/src/ZLogger/LogStates/StringFormatterLogState.cs
+++ b/src/ZLogger/LogStates/StringFormatterLogState.cs
@@ -30,7 +30,7 @@ namespace ZLogger.LogStates
             }
         }
 
-        public IZLoggerEntry CreateEntry(LogInfo info)
+        public IZLoggerEntry CreateEntry(in LogInfo info)
         {
             return ZLoggerEntry<StringFormatterLogState<TState>>.Create(info, this);
         }

--- a/src/ZLogger/ZLoggerEntry.cs
+++ b/src/ZLogger/ZLoggerEntry.cs
@@ -51,7 +51,7 @@ namespace ZLogger
 
         public override string ToString() => state.ToString();
 
-        public IZLoggerEntry CreateEntry(LogInfo info) => state.CreateEntry(info);
+        public IZLoggerEntry CreateEntry(in LogInfo info) => state.CreateEntry(info);
         public int ParameterCount => state.ParameterCount;
         public bool IsSupportUtf8ParameterKey => state.IsSupportUtf8ParameterKey;
 

--- a/src/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger/ZLoggerExtensions.cs
@@ -6,26 +6,27 @@ namespace ZLogger
 {
     public static partial class ZLoggerExtensions
     {
-        public static void ZLog(this ILogger logger, LogLevel logLevel, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, logLevel, default, null, ref message);
+            ZLog(logger, logLevel, default, null, ref message, callerMemberName, callerFilePath, callerLineNumber);
         }
         
-        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, logLevel, eventId, null, ref message);
+            ZLog(logger, logLevel, eventId, null, ref message, callerMemberName, callerFilePath, callerLineNumber);
         }
         
-        public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, logLevel, default, exception, ref message);
+            ZLog(logger, logLevel, default, exception, ref message, callerMemberName, callerFilePath, callerLineNumber);
         }
-        
-        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+
+        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
             if (message.IsLoggerEnabled)
             {
                 var state = message.GetState();
+                state.CallerInfo = callerMemberName != null ? new LogCallerInfo(callerMemberName, callerFilePath ?? "", callerLineNumber) : null;
                 try
                 {
                     logger.Log(logLevel, eventId, new VersionedLogState(state), exception, static (state, ex) => state.ToString());
@@ -37,122 +38,122 @@ namespace ZLogger
             }
         }
 
-        public static void ZLogTrace(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message)
+        public static void ZLogTrace(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Trace, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogTrace(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message)
+        public static void ZLogTrace(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Trace, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogTrace(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message)
+        public static void ZLogTrace(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Trace, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLogTrace(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message)
+        public static void ZLogTrace(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Trace, eventId, exception, ref message.InnerHandler);
         }
 
-        public static void ZLogDebug(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message)
+        public static void ZLogDebug(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Debug, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogDebug(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message)
+        public static void ZLogDebug(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Debug, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogDebug(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message)
+        public static void ZLogDebug(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Debug, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLogDebug(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message)
+        public static void ZLogDebug(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Debug, eventId, exception, ref message.InnerHandler);
         }
 
-        public static void ZLogInformation(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message)
+        public static void ZLogInformation(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Information, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogInformation(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message)
+        public static void ZLogInformation(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Information, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogInformation(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message)
+        public static void ZLogInformation(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Information, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLogInformation(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message)
+        public static void ZLogInformation(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Information, eventId, exception, ref message.InnerHandler);
         }
 
-        public static void ZLogWarning(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message)
+        public static void ZLogWarning(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Warning, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogWarning(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message)
+        public static void ZLogWarning(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Warning, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogWarning(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message)
+        public static void ZLogWarning(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Warning, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLogWarning(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message)
+        public static void ZLogWarning(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Warning, eventId, exception, ref message.InnerHandler);
         }
 
-        public static void ZLogError(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message)
+        public static void ZLogError(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Error, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogError(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message)
+        public static void ZLogError(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Error, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogError(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message)
+        public static void ZLogError(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Error, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLogError(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message)
+        public static void ZLogError(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Error, eventId, exception, ref message.InnerHandler);
         }
 
-        public static void ZLogCritical(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message)
+        public static void ZLogCritical(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Critical, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogCritical(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message)
+        public static void ZLogCritical(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Critical, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLogCritical(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message)
+        public static void ZLogCritical(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Critical, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLogCritical(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message)
+        public static void ZLogCritical(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.Critical, eventId, exception, ref message.InnerHandler);
         }

--- a/src/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger/ZLoggerExtensions.cs
@@ -26,7 +26,9 @@ namespace ZLogger
             if (message.IsLoggerEnabled)
             {
                 var state = message.GetState();
-                state.CallerInfo = callerMemberName != null ? new LogCallerInfo(callerMemberName, callerFilePath ?? "", callerLineNumber) : null;
+                state.CallerMemberName = callerMemberName;
+                state.CallerFilePath = callerFilePath;
+                state.CallerLineNumber = callerLineNumber;
                 try
                 {
                     logger.Log(logLevel, eventId, new VersionedLogState(state), exception, static (state, ex) => state.ToString());

--- a/src/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger/ZLoggerExtensions.cs
@@ -26,7 +26,7 @@ namespace ZLogger
             if (message.IsLoggerEnabled)
             {
                 var state = message.GetState();
-                state.CallerInfo = new LogCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
+                state.CallerInfo = callerMemberName != null ? new LogCallerInfo(callerMemberName, callerFilePath ?? "", callerLineNumber) : null;
                 try
                 {
                     logger.Log(logLevel, eventId, new VersionedLogState(state), exception, static (state, ex) => state.ToString());
@@ -38,124 +38,124 @@ namespace ZLogger
             }
         }
 
-        public static void ZLogTrace(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogTrace(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Trace, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Trace, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogTrace(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogTrace(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Trace, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Trace, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogTrace(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogTrace(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Trace, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Trace, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogTrace(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogTrace(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerTraceInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Trace, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Trace, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
 
-        public static void ZLogDebug(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogDebug(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Debug, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Debug, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogDebug(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogDebug(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Debug, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Debug, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogDebug(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogDebug(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Debug, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Debug, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogDebug(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogDebug(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerDebugInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Debug, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Debug, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
 
-        public static void ZLogInformation(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogInformation(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Information, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Information, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogInformation(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogInformation(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Information, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Information, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogInformation(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogInformation(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Information, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Information, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogInformation(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogInformation(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerInformationInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Information, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Information, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
 
-        public static void ZLogWarning(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogWarning(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Warning, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Warning, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogWarning(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogWarning(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Warning, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Warning, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogWarning(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogWarning(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Warning, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Warning, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogWarning(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogWarning(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerWarningInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Warning, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Warning, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
 
-        public static void ZLogError(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogError(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Error, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Error, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogError(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogError(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Error, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Error, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogError(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogError(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Error, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Error, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogError(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogError(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerErrorInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Error, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Error, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
 
-        public static void ZLogCritical(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogCritical(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Critical, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Critical, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogCritical(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogCritical(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Critical, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Critical, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogCritical(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogCritical(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Critical, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Critical, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLogCritical(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLogCritical(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLoggerCriticalInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.Critical, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.Critical, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
     }
 }

--- a/src/ZLogger/ZLoggerExtensions.cs
+++ b/src/ZLogger/ZLoggerExtensions.cs
@@ -26,9 +26,7 @@ namespace ZLogger
             if (message.IsLoggerEnabled)
             {
                 var state = message.GetState();
-                state.CallerMemberName = callerMemberName;
-                state.CallerFilePath = callerFilePath;
-                state.CallerLineNumber = callerLineNumber;
+                state.CallerInfo = new LogCallerInfo(callerMemberName, callerFilePath, callerLineNumber);
                 try
                 {
                     logger.Log(logLevel, eventId, new VersionedLogState(state), exception, static (state, ex) => state.ToString());

--- a/src/ZLogger/ZLoggerExtensions.tt
+++ b/src/ZLogger/ZLoggerExtensions.tt
@@ -15,26 +15,27 @@ namespace ZLogger
 {
     public static partial class ZLoggerExtensions
     {
-        public static void ZLog(this ILogger logger, LogLevel logLevel, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, logLevel, default, null, ref message);
+            ZLog(logger, logLevel, default, null, ref message, callerMemberName, callerFilePath, callerLineNumber);
         }
         
-        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, logLevel, eventId, null, ref message);
+            ZLog(logger, logLevel, eventId, null, ref message, callerMemberName, callerFilePath, callerLineNumber);
         }
         
-        public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+        public static void ZLog(this ILogger logger, LogLevel logLevel, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, logLevel, default, exception, ref message);
+            ZLog(logger, logLevel, default, exception, ref message, callerMemberName, callerFilePath, callerLineNumber);
         }
-        
-        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")]ref ZLoggerInterpolatedStringHandler message)
+
+        public static void ZLog(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger", "logLevel")] ref ZLoggerInterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
             if (message.IsLoggerEnabled)
             {
                 var state = message.GetState();
+                state.CallerInfo = callerMemberName != null ? new LogCallerInfo(callerMemberName, callerFilePath ?? "", callerLineNumber) : null;
                 try
                 {
                     logger.Log(logLevel, eventId, new VersionedLogState(state), exception, static (state, ex) => state.ToString());
@@ -47,22 +48,22 @@ namespace ZLogger
         }
 <# foreach(var logLevel in logLevels) { #>
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message)
+        public static void ZLog<#= logLevel #>(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.<#= logLevel #>, default, null, ref message.InnerHandler);
         } 
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message)
+        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.<#= logLevel #>, eventId, null, ref message.InnerHandler);
         } 
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message)
+        public static void ZLog<#= logLevel #>(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.<#= logLevel #>, default, exception, ref message.InnerHandler);
         } 
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message)
+        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
         {
             ZLog(logger, LogLevel.<#= logLevel #>, eventId, exception, ref message.InnerHandler);
         }

--- a/src/ZLogger/ZLoggerExtensions.tt
+++ b/src/ZLogger/ZLoggerExtensions.tt
@@ -35,7 +35,9 @@ namespace ZLogger
             if (message.IsLoggerEnabled)
             {
                 var state = message.GetState();
-                state.CallerInfo = callerMemberName != null ? new LogCallerInfo(callerMemberName, callerFilePath ?? "", callerLineNumber) : null;
+                state.CallerMemberName = callerMemberName;
+                state.CallerFilePath = callerFilePath;
+                state.CallerLineNumber = callerLineNumber;
                 try
                 {
                     logger.Log(logLevel, eventId, new VersionedLogState(state), exception, static (state, ex) => state.ToString());

--- a/src/ZLogger/ZLoggerExtensions.tt
+++ b/src/ZLogger/ZLoggerExtensions.tt
@@ -48,24 +48,24 @@ namespace ZLogger
         }
 <# foreach(var logLevel in logLevels) { #>
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLog<#= logLevel #>(this ILogger logger, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.<#= logLevel #>, default, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.<#= logLevel #>, default, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.<#= logLevel #>, eventId, null, ref message.InnerHandler);
+            ZLog(logger, LogLevel.<#= logLevel #>, eventId, null, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLog<#= logLevel #>(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.<#= logLevel #>, default, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.<#= logLevel #>, default, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         } 
 
-        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string? callerMemberName = null)
+        public static void ZLog<#= logLevel #>(this ILogger logger, EventId eventId, Exception? exception, [InterpolatedStringHandlerArgument("logger")] ref ZLogger<#= logLevel #>InterpolatedStringHandler message, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         {
-            ZLog(logger, LogLevel.<#= logLevel #>, eventId, exception, ref message.InnerHandler);
+            ZLog(logger, LogLevel.<#= logLevel #>, eventId, exception, ref message.InnerHandler, callerMemberName, callerFilePath, callerLineNumber);
         }
 <# } #>
     }

--- a/src/ZLogger/ZLoggerLogger.cs
+++ b/src/ZLogger/ZLoggerLogger.cs
@@ -25,9 +25,17 @@ namespace ZLogger
                 ? LogScopeState.Create(scopeProvider)
                 : null;
 
+            var callerMemberName = default(string?);
+            var callerFilePath = default(string?);
+            var callerLineNumber = default(int);
+            if (state is ICallerTracable)
+            {
+                callerMemberName = ((ICallerTracable)state).CallerMemberName;
+                callerFilePath = ((ICallerTracable)state).CallerFilePath;
+                callerLineNumber = ((ICallerTracable)state).CallerLineNumber;
+            }
 
-            var callerInfo = state is ICallerTracable ? ((ICallerTracable)state).CallerInfo : null;
-            var info = new LogInfo(category, new Timestamp(timeProvider), logLevel, eventId, exception, scopeState, callerInfo);
+            var info = new LogInfo(category, new Timestamp(timeProvider), logLevel, eventId, exception, scopeState, callerMemberName, callerFilePath, callerLineNumber);
             
             IZLoggerEntry entry;
             if (state is VersionedLogState)

--- a/src/ZLogger/ZLoggerLogger.cs
+++ b/src/ZLogger/ZLoggerLogger.cs
@@ -25,13 +25,9 @@ namespace ZLogger
                 ? LogScopeState.Create(scopeProvider)
                 : null;
 
-            var info = new LogInfo(category, new Timestamp(timeProvider), logLevel, eventId, exception, scopeState);
-            if (state is ICallerInfo)
-            {
-                info.CallerMemberName = ((ICallerInfo)state).CallerMemberName;
-                info.CallerFileName = ((ICallerInfo)state).CallerFilePath;
-                info.CallerLineNumber = ((ICallerInfo)state).CallerLineNumber;
-            } 
+
+            var callerInfo = state is ICallerTracable ? ((ICallerTracable)state).CallerInfo : null;
+            var info = new LogInfo(category, new Timestamp(timeProvider), logLevel, eventId, exception, scopeState, callerInfo);
             
             IZLoggerEntry entry;
             if (state is VersionedLogState)

--- a/tests/ZLogger.Generator.Tests/GenerateTest.cs
+++ b/tests/ZLogger.Generator.Tests/GenerateTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using ZLogger.Generator.Tests;
 
 namespace ZLogger.Tests.GeneratorTests
@@ -10,6 +11,9 @@ namespace ZLogger.Tests.GeneratorTests
         // check for instance
         [ZLoggerMessage(Information, "Hello {name}")]
         partial void Hello(ILogger logger, string name);
+
+        [ZLoggerMessage(Information, "Bye {name}")]
+        partial void Bye(ILogger logger, string name, [CallerMemberName] string memberName = "");
 
 
         [Fact]

--- a/tests/ZLogger.Tests/CallerInfoTest.cs
+++ b/tests/ZLogger.Tests/CallerInfoTest.cs
@@ -1,9 +1,9 @@
 namespace ZLogger.Tests;
 
-public class CallerInfoTest
+public class LogCallerInfoTest
 {
     [Fact]
-    public void CaptureCallerInfo()
+    public void CallerInfo()
     {
         var processor = new TestProcessor(new ZLoggerOptions());
 
@@ -17,7 +17,7 @@ public class CallerInfoTest
         logger.ZLogInformation($"aaaa");
 
         var x = processor.Entries.Dequeue();
-        x.LogInfo.CallerInfo!.Value.MemberName.Should().NotBeEmpty();
+        x.LogInfo.CallerInfo!.Value.MemberName.Should().Be("CallerInfo");
         x.LogInfo.CallerInfo!.Value.FilePath.Should().NotBeEmpty();
         x.LogInfo.CallerInfo!.Value.LineNumber.Should().BeGreaterThan(1);
     }

--- a/tests/ZLogger.Tests/CallerInfoTest.cs
+++ b/tests/ZLogger.Tests/CallerInfoTest.cs
@@ -19,8 +19,8 @@ public class LogCallerInfoTest
         logger.ZLogInformation($"aaaa");
 
         var x = processor.Entries.Dequeue();
-        x.LogInfo.CallerInfo!.Value.MemberName.Should().Be("CallerInfo");
-        Path.GetFileName(x.LogInfo.CallerInfo!.Value.FilePath).Should().Be("CallerInfoTest.cs");
-        x.LogInfo.CallerInfo!.Value.LineNumber.Should().Be(19);
+        x.LogInfo.CallerMemberName.Should().Be("CallerInfo");
+        Path.GetFileName(x.LogInfo.CallerFilePath).Should().Be("CallerInfoTest.cs");
+        x.LogInfo.CallerLineNumber.Should().Be(19);
     }
 }

--- a/tests/ZLogger.Tests/CallerInfoTest.cs
+++ b/tests/ZLogger.Tests/CallerInfoTest.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace ZLogger.Tests;
 
 public class LogCallerInfoTest
@@ -18,7 +20,7 @@ public class LogCallerInfoTest
 
         var x = processor.Entries.Dequeue();
         x.LogInfo.CallerInfo!.Value.MemberName.Should().Be("CallerInfo");
-        x.LogInfo.CallerInfo!.Value.FilePath.Should().NotBeEmpty();
-        x.LogInfo.CallerInfo!.Value.LineNumber.Should().BeGreaterThan(1);
+        Path.GetFileName(x.LogInfo.CallerInfo!.Value.FilePath).Should().Be("CallerInfoTest.cs");
+        x.LogInfo.CallerInfo!.Value.LineNumber.Should().Be(19);
     }
 }

--- a/tests/ZLogger.Tests/CallerInfoTest.cs
+++ b/tests/ZLogger.Tests/CallerInfoTest.cs
@@ -1,0 +1,24 @@
+namespace ZLogger.Tests;
+
+public class CallerInfoTest
+{
+    [Fact]
+    public void CaptureCallerInfo()
+    {
+        var processor = new TestProcessor(new ZLoggerOptions());
+
+        var loggerFactory = LoggerFactory.Create(x =>
+        {
+            x.SetMinimumLevel(LogLevel.Debug);
+            x.AddZLoggerLogProcessor(_ => processor);
+        });
+        var logger = loggerFactory.CreateLogger("test");
+        
+        logger.ZLogInformation($"aaaa");
+
+        var x = processor.Entries.Dequeue();
+        x.LogInfo.CallerInfo!.Value.MemberName.Should().NotBeEmpty();
+        x.LogInfo.CallerInfo!.Value.FilePath.Should().NotBeEmpty();
+        x.LogInfo.CallerInfo!.Value.LineNumber.Should().BeGreaterThan(1);
+    }
+}

--- a/tests/ZLogger.Tests/InterpolatedManyTypesTest.cs
+++ b/tests/ZLogger.Tests/InterpolatedManyTypesTest.cs
@@ -34,10 +34,10 @@ namespace ZLogger.Tests
 
             logger.ZLogInformation($"f:{foo} b:{bar} d:{dt:yyyy-MM-dd} n:{dtn} s:{seq} v:{vec:json} v2:{vec2:@v2:json}");
 
-            var msg = stringProcessor.Dequeue();
+            var msg = stringProcessor.DequeueAsString();
             msg.Should().Be("f:10 b: d:1999-12-10 n: s:[1,2,3,4,5] v:{\"X\":1,\"Y\":2,\"Z\":3} v2:{\"X\":4,\"Y\":5,\"Z\":6}");
 
-            var json = jsonProcessor.Dequeue();
+            var json = jsonProcessor.DequeueAsString();
             json.Should().Be("""
 {"foo":10,"bar":null,"dt":"1999-12-10T00:00:00","dtn":null,"seq":[1,2,3,4,5],"vec":{"X":1,"Y":2,"Z":3},"v2":{"X":4,"Y":5,"Z":6}}
 """);

--- a/tests/ZLogger.Tests/JsonFormatTest.cs
+++ b/tests/ZLogger.Tests/JsonFormatTest.cs
@@ -1,5 +1,3 @@
-using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Text;
@@ -78,7 +76,7 @@ namespace ZLogger.Tests
             var now = DateTime.UtcNow;
             logger.ZLogInformation(new EventId(1, "TEST"), $"HELLO!");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.TryGetProperty("Message", out _).Should().BeFalse();
@@ -108,7 +106,7 @@ namespace ZLogger.Tests
 
             logger.ZLogInformation(new EventId(1, "TEST"), $"HELLO!");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.TryGetProperty("Message", out _).Should().BeFalse();
@@ -145,7 +143,7 @@ namespace ZLogger.Tests
             var Yaki = "あいうえお";
             logger.ZLogDebug($"tako: {Tako} yaki: {Yaki}");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
@@ -178,7 +176,7 @@ namespace ZLogger.Tests
 
             logger.ZLogDebug($"tako: {zzz.Tako} yaki: {zzz.Yaki}");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
@@ -211,7 +209,7 @@ namespace ZLogger.Tests
 
             logger.ZLogDebug($"tako: {zzz.tako} yaki: {zzz.yaki}");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
@@ -245,7 +243,7 @@ namespace ZLogger.Tests
 
             logger.ZLogDebug($"tako: {zzz.Tako} yaki: {zzz.Yaki}");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.GetProperty("Message").GetString().Should().Be("tako: 100 yaki: あいうえお");
@@ -281,7 +279,7 @@ namespace ZLogger.Tests
 
             logger.ZLogInformation(new EventId(1, "TEST"), $"HELLO!");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.TryGetProperty("MMMMMMMMMMMOsage", out _).Should().BeTrue();
@@ -320,7 +318,7 @@ namespace ZLogger.Tests
             var mc = new MyClass();
             logger.ZLogDebug($"tako: {mc.Call(10, anon.Tako)} yaki: {(((mc.Call2(1, 2))))}");
 
-            var json = processor.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.GetProperty("Call").GetInt32().Should().Be(110);

--- a/tests/ZLogger.Tests/NamedParamTest.cs
+++ b/tests/ZLogger.Tests/NamedParamTest.cs
@@ -24,7 +24,7 @@ namespace ZLogger.Tests
 
             logger.ZLogInformation($"{100:@TAKO} {200:@YAKI:D5} {new DateTime(2023, 12, 31),15:@T:yyyy-MM-dd}");
 
-            var json = processor.EntryMessages.Dequeue();
+            var json = processor.DequeueAsString();
             var doc = JsonDocument.Parse(json).RootElement;
 
             doc.GetProperty("Message").GetString().Should().Be("100 00200      2023-12-31");

--- a/tests/ZLogger.Tests/PlainTextFormatTest.cs
+++ b/tests/ZLogger.Tests/PlainTextFormatTest.cs
@@ -27,53 +27,53 @@ namespace ZLogger.Tests
             var logger = loggerFactory.CreateLogger("test");
 
             logger.ZLogDebug($"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLogDebug(new EventId(10), $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLogDebug(new Exception(), $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLogDebug(new EventId(10), new Exception(), $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             var bar = "bar";
             logger.ZLogDebug($"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLogDebug(new EventId(10), $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLogDebug(new Exception(), $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLogDebug(new EventId(10), new Exception(), $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLog(LogLevel.Debug, $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLog(LogLevel.Debug, new EventId(10), $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLog(LogLevel.Debug, new Exception(), $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLog(LogLevel.Debug, new EventId(10), new Exception(), $"foo");
-            processor.EntryMessages.Dequeue().Should().Be("foo");
+            processor.DequeueAsString().Should().Be("foo");
 
             logger.ZLog(LogLevel.Debug, $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLog(LogLevel.Debug, new EventId(10), $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLog(LogLevel.Debug, new Exception(), $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
 
             logger.ZLog(LogLevel.Debug, new EventId(10), new Exception(), $"foo {bar}");
-            processor.EntryMessages.Dequeue().Should().Be("foo bar");
+            processor.DequeueAsString().Should().Be("foo bar");
         }
 
         [Fact]
@@ -98,17 +98,17 @@ namespace ZLogger.Tests
             var x = 100;
             var y = 200;
             logger.ZLogDebug($"FooBar{x}-NanoNano{y}");
-            processsor.Dequeue().Should().Be("[Pre:Debug]FooBar100-NanoNano200[Suf:test]");
+            processsor.DequeueAsString().Should().Be("[Pre:Debug]FooBar100-NanoNano200[Suf:test]");
 
             logger.ZLogInformation($"FooBar{x}-NanoNano{y}");
-            processsor.Dequeue().Should().Be("[Pre:Information]FooBar100-NanoNano200[Suf:test]");
+            processsor.DequeueAsString().Should().Be("[Pre:Information]FooBar100-NanoNano200[Suf:test]");
 
             // fallback case
             logger.LogDebug("FooBar{0}-NanoNano{1}", 100, 200);
-            processsor.Dequeue().Should().Be("[Pre:Debug]FooBar100-NanoNano200[Suf:test]");
+            processsor.DequeueAsString().Should().Be("[Pre:Debug]FooBar100-NanoNano200[Suf:test]");
 
             logger.LogInformation("FooBar{0}-NanoNano{1}", 100, 300);
-            processsor.Dequeue().Should().Be("[Pre:Information]FooBar100-NanoNano300[Suf:test]");
+            processsor.DequeueAsString().Should().Be("[Pre:Information]FooBar100-NanoNano300[Suf:test]");
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace ZLogger.Tests
 
             logger.ZLogDebug($"array: {array} enumerable: {enumerable}");
 
-            var message = processor.Dequeue();
+            var message = processor.DequeueAsString();
             message.Should().Be("array: [111,222,333] enumerable: [\"a\",\"i\",\"u\",\"e\"]");
         }
     }

--- a/tests/ZLogger.Tests/ScopeTest.cs
+++ b/tests/ZLogger.Tests/ScopeTest.cs
@@ -44,7 +44,7 @@ public class ScopeTest
             logger.ZLogInformation($"FooBar{x} NanoNano{y}");
         }
 
-        var doc = JsonDocument.Parse(processor.Dequeue()).RootElement;
+        var doc = JsonDocument.Parse(processor.DequeueAsString()).RootElement;
         doc.GetProperty("Message").GetString().Should().Be("FooBar333 NanoNano444");
         doc.GetProperty("X").GetInt32().Should().Be(111);
         doc.GetProperty("Y").ValueKind.Should().Be(JsonValueKind.Null);
@@ -60,7 +60,7 @@ public class ScopeTest
             logger.ZLogInformation($"FooBar{x} NanoNano{y}");
         }
 
-        var doc = JsonDocument.Parse(processor.Dequeue()).RootElement;
+        var doc = JsonDocument.Parse(processor.DequeueAsString()).RootElement;
 
         doc.GetProperty("Message").GetString().Should().Be("FooBar100 NanoNano200");
         doc.GetProperty("Hoge").GetString().Should().Be("AAA");
@@ -76,7 +76,7 @@ public class ScopeTest
             logger.ZLogInformation($"FooBar{x} NanoNano{y}");
         }
 
-        var json = processor.Dequeue();
+        var json = processor.DequeueAsString();
         var doc = JsonDocument.Parse(json).RootElement;
         doc.GetProperty("Message").GetString().Should().Be("FooBar100 NanoNano200");
             
@@ -97,8 +97,8 @@ public class ScopeTest
             }
         }
 
-        var log1 = JsonDocument.Parse(processor.Dequeue()).RootElement;
-        var log2 = JsonDocument.Parse(processor.Dequeue()).RootElement;
+        var log1 = JsonDocument.Parse(processor.DequeueAsString()).RootElement;
+        var log2 = JsonDocument.Parse(processor.DequeueAsString()).RootElement;
 
         log1.GetProperty("Message").GetString().Should().Be("Message 1");
         log1.GetProperty("X").GetInt32().Should().Be(111);

--- a/tests/ZLogger.Tests/TestHelpers.cs
+++ b/tests/ZLogger.Tests/TestHelpers.cs
@@ -7,10 +7,10 @@ namespace ZLogger.Tests
 {
     class TestProcessor : IAsyncLogProcessor
     {
-        public Queue<string> EntryMessages = new();
+        public readonly Queue<IZLoggerEntry> Entries = new();
         readonly IZLoggerFormatter formatter;
 
-        public string Dequeue() => EntryMessages.Dequeue();
+        public string DequeueAsString() => Entries.Dequeue().FormatToString(formatter);
 
         public TestProcessor(ZLoggerOptions options)
         {
@@ -24,7 +24,7 @@ namespace ZLogger.Tests
 
         public void Post(IZLoggerEntry log)
         {
-            EntryMessages.Enqueue(log.FormatToString(formatter));
+            Entries.Enqueue(log);
         }
     }
 


### PR DESCRIPTION
#140 

Add the following arguments to the ZLog method to support compiler tracing of callers.
- `[CallerMemberName]`
- `[CallerFilePath]`
- `[CallerLineNumber]`