### PR TITLE
Fix not correct implementation CreateEntry which causes compile errors

### DIFF
--- a/src/ZLogger.Unity/Assets/ZLogger.Unity/Runtime/UnityDebugLogState.cs
+++ b/src/ZLogger.Unity/Assets/ZLogger.Unity/Runtime/UnityDebugLogState.cs
@@ -22,7 +22,7 @@ struct UnityDebugLogState : IZLoggerFormattable, IReferenceCountable
         version = state.Version;
     }
 
-    public IZLoggerEntry CreateEntry(LogInfo info)
+    public IZLoggerEntry CreateEntry(in LogInfo info)
     {
         return ZLoggerEntry<UnityDebugLogState>.Create(info, this);
     }


### PR DESCRIPTION
fixes 

```
\Runtime\UnityDebugLogState.cs(8,29): error CS0535: 'UnityDebugLogState' does not implement interface member 'IZLoggerEntryCreatable.CreateEntry(in LogInfo)'
```