### PR TITLE
ci: Cysharp/Actions/.github/workflows/create-release.yaml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,18 +11,15 @@ on:
         required: true
         default: false
         type: boolean
-        
-env:
-  GIT_TAG: ${{ github.event.inputs.tag }}
-  
+
 jobs:
   update-packagejson:
     uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
     with:
       file-path: ./src/ZLogger.Unity/Assets/ZLogger.Unity/package.json
-      tag: ${{ github.event.inputs.tag }}
-      dry-run: ${{ fromJson(github.event.inputs.dry-run) }}
- 
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+
   build-dotnet:
     needs: [update-packagejson]
     runs-on: ubuntu-latest
@@ -38,28 +35,25 @@ jobs:
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
-      - run: dotnet nuget push "./publish/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-
-  # release
-  create-release:
-    if: github.event.inputs.dry-run == 'false'    
-    needs: [update-packagejson, build-dotnet]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # Create Releases
-      - uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Store artifacts.
+      - uses: actions/upload-artifact@v2
         with:
-          tag_name: ${{ env.GIT_TAG }}
-          release_name: Ver.${{ env.GIT_TAG }}
-          draft: true
-          prerelease: false
+          name: nuget
+          path: ./publish/
+
+  create-release:
+    needs: [update-packagejson, build-dotnet]
+    uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
+    with:
+      commit-id: ${{ needs.update-packagejson.outputs.sha }}
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+      nuget-push: true
+      release-upload: false
+    secrets: inherit
 
   cleanup:
-    if: needs.update-packagejson.outputs.is-branch-created == 'true'
+    if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}
     needs: [update-packagejson, build-dotnet]
     uses: Cysharp/Actions/.github/workflows/clean-packagejson-branch.yaml@main
     with:


### PR DESCRIPTION
## tl;dr;

Replace create-release with `Cysharp/Actions/.github/workflows/create-release.yaml`.

This brings central managed release flow control.

see: https://github.com/Cysharp/ZLogger/actions/runs/7814625784