### PR TITLE
Make sure that resources.dat files are included in the build

### DIFF
--- a/src/ZLogger/ZLogger.csproj
+++ b/src/ZLogger/ZLogger.csproj
@@ -15,7 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="../../Icon.png" Pack="true" PackagePath="/" />
+		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
+		<EmbeddedResource Include="..\..\LICENSE" />
 		<InternalsVisibleTo Include="ZLogger.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000144ec28f1e9ef7b17dacc47425a7a153aea0a7baa590743a2d1a86f4b3e10a8a12712c6e647966bfd8bd6e830048b23bd42bbc56f179585c15b8c19cf86c0eed1b73c993dd7a93a30051dd50fdda0e4d6b65e6874e30f1c37cf8bcbc7fe02c7f2e6a0a3327c0ccc1631bf645f40732521fa0b41a30c178d08f7dd779d42a1ee" />
 	</ItemGroup>
 


### PR DESCRIPTION
For reasons other than functional requirements, make sure that license files are included in the build .

We have some kind of EmbeddedResource in the dll,

If dll has some kind of EmbeddedResource,
IL2CPP will create a `{Package}.dll-resources.dat` file.

<img width="594" alt="スクリーンショット 2024-02-09 15 09 44" src="https://github.com/Cysharp/ZLogger/assets/727159/e053aaeb-374c-45df-b9fa-88fd06817241">
 