### PR TITLE
Fixed language version for props file

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,7 +797,7 @@ Installation steps:
         - ```xml
           <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
             <PropertyGroup>
-              <LangVersion>10</LangVersion>
+              <LangVersion>10.0</LangVersion>
               <Nullable>enable</Nullable>
             </PropertyGroup>
           </Project>


### PR DESCRIPTION
I could not get it to work with just "10" as language version in Visual Studio Pro 2022 Version 17.10.0.
Using "10.0" fixed the error for me
