### PR TITLE
Fix NativeAOT and remove warnings

### DIFF
--- a/sandbox/ConsoleApp/SampleCustomFormatter.cs
+++ b/sandbox/ConsoleApp/SampleCustomFormatter.cs
@@ -46,7 +46,7 @@ internal class CLEFMessageTemplateFormatter : IZLoggerFormatter
     Utf8JsonWriter? jsonWriter;
     ArrayBufferWriter<byte> originalFormatWriter = new ArrayBufferWriter<byte>();
 
-    public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+    public void FormatLogEntry(IBufferWriter<byte> writer, IZLoggerEntry entry)
     {
         // FormatLogEntry is guaranteed call in single-thread so reuse Utf8JsonWriter
         jsonWriter?.Reset(writer);

--- a/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
+++ b/src/ZLogger.MessagePack/MessagePackZLoggerFormatter.cs
@@ -79,7 +79,7 @@ public class MessagePackZLoggerFormatter : IZLoggerFormatter
     public MessagePackPropertyNames PropertyNames { get; set; } = MessagePackPropertyNames.Default;
     public IKeyNameMutator? KeyNameMutator { get; set; }
 
-    public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+    public void FormatLogEntry(IBufferWriter<byte> writer, IZLoggerEntry entry)
     {
         var messagePackWriter = new MessagePackWriter(writer);
         var propCount = BitOperations.PopCount((uint)IncludeProperties);

--- a/src/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/PlainTextZLoggerFormatter.cs
@@ -35,7 +35,7 @@ namespace ZLogger.Formatters
             this.exceptionFormatter = formatter;
         }
 
-        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+        public void FormatLogEntry(IBufferWriter<byte> writer, IZLoggerEntry entry)
         {
             if (prefixTemplate != null)
             {

--- a/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -126,7 +127,9 @@ namespace ZLogger.Formatters
 
         Utf8JsonWriter? jsonWriter;
 
-        public void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry) where TEntry : IZLoggerEntry
+        [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
+        public void FormatLogEntry(IBufferWriter<byte> writer, IZLoggerEntry entry)
         {
             jsonWriter?.Reset(writer);
             jsonWriter ??= new Utf8JsonWriter(writer);

--- a/src/ZLogger/IZLoggerFormatter.cs
+++ b/src/ZLogger/IZLoggerFormatter.cs
@@ -6,7 +6,6 @@ namespace ZLogger
     public interface IZLoggerFormatter
     {
         bool WithLineBreak { get; }
-        void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry)
-            where TEntry : IZLoggerEntry;
+        void FormatLogEntry(IBufferWriter<byte> writer, IZLoggerEntry entry);
     }
 }

--- a/src/ZLogger/Internal/CodeGeneratorUtil.cs
+++ b/src/ZLogger/Internal/CodeGeneratorUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Utf8StringInterpolation;
 
@@ -25,7 +26,9 @@ namespace ZLogger.Internal
             return writer;
         }
 
-        public static void AppendAsJson<T>(ref Utf8StringWriter<IBufferWriter<byte>> stringWriter, T value)
+        [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
+        public static void AppendAsJson<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(ref Utf8StringWriter<IBufferWriter<byte>> stringWriter, T value)
         {
             stringWriter.ClearState();
 
@@ -35,6 +38,8 @@ namespace ZLogger.Internal
             utf8JsonWriter.Reset();
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
         public static void AppendAsJson(ref Utf8StringWriter<IBufferWriter<byte>> stringWriter, object? value, Type inputType)
         {
             stringWriter.ClearState();
@@ -45,7 +50,7 @@ namespace ZLogger.Internal
             utf8JsonWriter.Reset();
         }
 
-        public static unsafe void WriteJsonEnum<T>(Utf8JsonWriter writer, JsonEncodedText key, T value)
+        public static unsafe void WriteJsonEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Utf8JsonWriter writer, JsonEncodedText key, T value)
         {
             var enumValue = EnumDictionary<T>.GetJsonEncodedName(value);
             if (enumValue == null)

--- a/src/ZLogger/Internal/EnumDictionary.cs
+++ b/src/ZLogger/Internal/EnumDictionary.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 
 namespace ZLogger.Internal;
 
-internal static unsafe class EnumDictionary<T>
+internal static unsafe class EnumDictionary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
 {
     static object dictionary;
 
@@ -16,10 +16,11 @@ internal static unsafe class EnumDictionary<T>
     public static readonly delegate* managed<T, ReadOnlySpan<byte>> GetUtf8Name; // be careful, zero is not found.
     public static readonly delegate* managed<T, JsonEncodedText?> GetJsonEncodedName;
 
+    [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
     static EnumDictionary()
     {
         var type = typeof(T);
-
         var source = new List<(T, EnumName)>();
         foreach (var key in Enum.GetValues(type))
         {

--- a/src/ZLogger/Internal/MagicalBox.cs
+++ b/src/ZLogger/Internal/MagicalBox.cs
@@ -1,5 +1,6 @@
 ﻿using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Utf8StringInterpolation;
@@ -18,7 +19,7 @@ internal unsafe partial struct MagicalBox
 
     public int Written => written;
 
-    public bool TryWrite<T>(T value, out int offset)
+    public bool TryWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, out int offset)
     {
         if (!IsSupportedType<T>())
         {
@@ -307,7 +308,7 @@ internal unsafe partial struct MagicalBox
         public static bool TryReadTo(Type type, MagicalBox box, int offset, ref Utf8StringWriter<IBufferWriter<byte>> writer, int alignment, string? format) => cache.TryGetValue(type, out var value) ? value.Utf8StringWriter(box, offset, ref writer, alignment, format) : false;
         public static object? ReadBoxed(Type type, MagicalBox box, int offset) => cache.TryGetValue(type, out var value) ? value.ReadBoxed(box, offset) : null;
 
-        public static void Register<T>()
+        public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>()
         {
             if (IsRegistered<T>.Value)
             {
@@ -339,7 +340,7 @@ internal unsafe partial struct MagicalBox
             IsRegistered<T>.Value = true;
         }
 
-        static object? ReadBoxed<T>(MagicalBox box, int offset)
+        static object? ReadBoxed<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(MagicalBox box, int offset)
         {
             if (box.TryRead<T>(offset, out var v))
             {
@@ -348,7 +349,7 @@ internal unsafe partial struct MagicalBox
             return null;
         }
 
-        static bool EnumJsonWrite<T>(MagicalBox box, int offset, Utf8JsonWriter writer, JsonSerializerOptions? options)
+        static bool EnumJsonWrite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(MagicalBox box, int offset, Utf8JsonWriter writer, JsonSerializerOptions? options)
         {
             if (box.TryRead<T>(offset, out var v))
             {
@@ -436,7 +437,9 @@ internal unsafe partial struct MagicalBox
             return false;
         }
 
-        static bool JsonSerialize<T>(MagicalBox box, int offset, Utf8JsonWriter writer, JsonSerializerOptions? options)
+        [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
+        static bool JsonSerialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(MagicalBox box, int offset, Utf8JsonWriter writer, JsonSerializerOptions? options)
         {
             if (box.TryRead<T>(offset, out var v))
             {
@@ -447,7 +450,7 @@ internal unsafe partial struct MagicalBox
             return false;
         }
 
-        static bool StringAppendFormatted<T>(MagicalBox box, int offset, ref DefaultInterpolatedStringHandler handler, int alignment, string? format)
+        static bool StringAppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(MagicalBox box, int offset, ref DefaultInterpolatedStringHandler handler, int alignment, string? format)
         {
             if (box.TryRead<T>(offset, out var v))
             {
@@ -458,7 +461,7 @@ internal unsafe partial struct MagicalBox
             return false;
         }
 
-        static bool Utf8AppendFormatted<T>(MagicalBox box, int offset, ref Utf8StringWriter<IBufferWriter<byte>> writer, int alignment, string? format)
+        static bool Utf8AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(MagicalBox box, int offset, ref Utf8StringWriter<IBufferWriter<byte>> writer, int alignment, string? format)
         {
             if (box.TryRead<T>(offset, out var v))
             {

--- a/src/ZLogger/LogStates/InterpolatedStringLogState.cs
+++ b/src/ZLogger/LogStates/InterpolatedStringLogState.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using ZLogger.Formatters;
@@ -114,6 +115,8 @@ public sealed class InterpolatedStringLogState :
         messageSequence.WriteOriginalFormat(writer, parameters);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
     public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, IKeyNameMutator? keyNameMutator = null)
     {
         for (var i = 0; i < ParameterCount; i++)

--- a/src/ZLogger/LogStates/StringFormatterLogState.cs
+++ b/src/ZLogger/LogStates/StringFormatterLogState.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using ZLogger.Internal;
@@ -81,6 +82,8 @@ namespace ZLogger.LogStates
             }
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
         public void WriteJsonParameterKeyValues(Utf8JsonWriter jsonWriter, JsonSerializerOptions jsonSerializerOptions, IKeyNameMutator? keyNameMutator = null)
         {
             if (originalStateParameters == null) return;

--- a/src/ZLogger/ZLogger.csproj
+++ b/src/ZLogger/ZLogger.csproj
@@ -8,11 +8,19 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1701;1702;1591;1573</NoWarn>
 
-		<!-- NuGet Packaging -->
+    <!-- Enable for using [DynamicallyAccessedMembers] attribute -->
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+
+    <!-- NuGet Packaging -->
 		<PackageTags>logging;</PackageTags>
 		<Description>Zero Allocation Text/Strcutured Logger for .NET Core, built on top of a Microsoft.Extensions.Logging.</Description>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
+
+	<PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
+    <!-- Enable AOT analyzers -->
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
 
 	<ItemGroup>
 		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
@@ -36,7 +44,7 @@
 		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-		<PackageReference Include="PolySharp" Version="1.13.2">
+		<PackageReference Include="PolySharp" Version="1.14.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.LogLevel.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using ZLogger.LogStates;
 
@@ -18,18 +19,18 @@ public ref struct ZLoggerTraceInterpolatedStringHandler
         InnerHandler.AppendLiteral(s);
     }
 
-    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         InnerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         where T : struct
     {
         InnerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
     {
         InnerHandler.AppendFormatted(namedValue, alignment, format);
     }
@@ -49,18 +50,18 @@ public ref struct ZLoggerDebugInterpolatedStringHandler
         InnerHandler.AppendLiteral(s);
     }
 
-    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         InnerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         where T : struct
     {
         InnerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
     {
         InnerHandler.AppendFormatted(namedValue, alignment, format);
     }
@@ -80,18 +81,18 @@ public ref struct ZLoggerInformationInterpolatedStringHandler
         InnerHandler.AppendLiteral(s);
     }
 
-    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         InnerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         where T : struct
     {
         InnerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
     {
         InnerHandler.AppendFormatted(namedValue, alignment, format);
     }
@@ -111,18 +112,18 @@ public ref struct ZLoggerWarningInterpolatedStringHandler
         InnerHandler.AppendLiteral(s);
     }
 
-    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         InnerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         where T : struct
     {
         InnerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
     {
         InnerHandler.AppendFormatted(namedValue, alignment, format);
     }
@@ -142,18 +143,18 @@ public ref struct ZLoggerErrorInterpolatedStringHandler
         InnerHandler.AppendLiteral(s);
     }
 
-    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         InnerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         where T : struct
     {
         InnerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
     {
         InnerHandler.AppendFormatted(namedValue, alignment, format);
     }
@@ -173,18 +174,18 @@ public ref struct ZLoggerCriticalInterpolatedStringHandler
         InnerHandler.AppendLiteral(s);
     }
 
-    public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
     {
         InnerHandler.AppendFormatted(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         where T : struct
     {
         InnerHandler.AppendFormatted<T>(value, alignment, format, argumentName);
     }
 
-    public void AppendFormatted<T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
+    public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>((string, T) namedValue, int alignment = 0, string? format = null, string? _ = null)
     {
         InnerHandler.AppendFormatted(namedValue, alignment, format);
     }

--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
@@ -82,7 +83,7 @@ namespace ZLogger
             literals.Add(s);
         }
 
-        public void AppendFormatted<T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
         {
             // Add for MessageSequence
             literals.Add(null);
@@ -120,7 +121,7 @@ namespace ZLogger
             state.parameters[parameterWritten++] = parameter;
         }
 
-        public void AppendFormatted<T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
+        public void AppendFormatted<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Nullable<T> value, int alignment = 0, string? format = null, [CallerArgumentExpression("value")] string? argumentName = null)
             where T : struct
         {
             // Nullable, check and unwrap here.
@@ -277,6 +278,8 @@ namespace ZLogger
             stringWriter.Flush();
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode")]
         public string ToString(MagicalBox box, Span<InterpolatedStringParameter> parameters)
         {
             var stringHandler = new DefaultInterpolatedStringHandler(literalLength, parametersLength);


### PR DESCRIPTION
Fixes #156

Hello there ☺️

This PR is attempting to fix the crash/incompatibility with NativeAOT:

- Breaking change for `IZLoggerFormatter` which shouldn't be an issue. In all the call sites of `FormatLogEntry`, `TEntry` is always `IZLoggerEntry` and not an actual value type, so forcing `IZLoggerEntry` on the interface will avoid the crash at NativeAOT runtime `Failed to create generic virtual method implementation` (In general, it's better to avoid generic method with generic parameters in interfaces):
  ```diff
    public interface IZLoggerFormatter
    {
        bool WithLineBreak { get; }
  -      void FormatLogEntry<TEntry>(IBufferWriter<byte> writer, TEntry entry)
  -           where TEntry : IZLoggerEntry;
  +      void FormatLogEntry(IBufferWriter<byte> writer, IZLoggerEntry entry);
    }
  ```
- Add several `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]` to generics mostly to help with the usage of Json behind the scene.
- Added a few `[UnconditionalSuppressMessage]` for `IL3050` and `IL2026` due to the usage of several methods from `JsonSerializer.Serialize` which takes an object. The ones that are using `JsonSerializerOptions` should be fine as the user can set its own instance to `SystemTextJsonZLoggerFormatter.JsonSerializerOptions` and initialize it with a NativeAOT/Source generator version. There are other places where `JsonSerializer.Serialize` is used, but without the options. I'm not sure exactly if it will be a problem (I'm not using JsonSerializer for now). Ideally the same `JsonSerializerOptions` should be propagated to all these places, but it looks like `JsonSerializer.Serialize` in these cases might be only used for primitives.