### PR TITLE
Use `ZeroLog.LogManager.Flush()` in benchmarks

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
 		<PackageReference Include="System.IO.Hashing" Version="8.0.0" />
-		<PackageReference Include="ZeroLog" Version="2.1.1" />
+		<PackageReference Include="ZeroLog" Version="2.2.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />

--- a/sandbox/Benchmark/Benchmarks/WriteJsonToConsole.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteJsonToConsole.cs
@@ -230,7 +230,7 @@ public class WriteJsonToConsole
                 .Log();
         }
 
-        ZeroLog.LogManager.Shutdown();
+        ZeroLog.LogManager.Flush();
     }
 
     [Benchmark]

--- a/sandbox/Benchmark/Benchmarks/WriteJsonToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WriteJsonToFile.cs
@@ -243,7 +243,7 @@ public class WriteJsonToFile
                 .Log();
         }
 
-        ZeroLog.LogManager.Shutdown();
+        ZeroLog.LogManager.Flush();
     }
 
     [Benchmark]

--- a/sandbox/Benchmark/Benchmarks/WritePlainTextToConsole.cs
+++ b/sandbox/Benchmark/Benchmarks/WritePlainTextToConsole.cs
@@ -204,7 +204,7 @@ public class WritePlainTextToConsole
             zeroLogLogger.Info($"Hello, {MessageSample.Arg1} lives in {MessageSample.Arg2} {MessageSample.Arg3} years old");
         }
 
-        ZeroLog.LogManager.Shutdown();
+        ZeroLog.LogManager.Flush();
     }
 
     [Benchmark]

--- a/sandbox/Benchmark/Benchmarks/WritePlainTextToFile.cs
+++ b/sandbox/Benchmark/Benchmarks/WritePlainTextToFile.cs
@@ -228,7 +228,7 @@ public class WritePlainTextToFile
             zeroLogLogger.Info($"Hello, {MessageSample.Arg1} lives in {MessageSample.Arg2} {MessageSample.Arg3} years old");
         }
 
-        ZeroLog.LogManager.Shutdown();
+        ZeroLog.LogManager.Flush();
     }
 
     [Benchmark]


### PR DESCRIPTION
This PR updates ZeroLog in benchmarks and replaces some usages of its `LogManager.Shutdown` method with `LogManager.Flush`.

When I sent #127, I made a note that we should expose a `Flush` method for benchmarking, as I had to use `Shutdown`, which worked but was incorrect (it allocates, takes a longer time, does more than necessary, etc). We were using an internal `WaitUntilQueueIsEmpty` method in ZeroLog benchmarks but I couldn't use it here. Oops. 😅

This PR therefore uses the new `Flush` method where it is the correct thing to do. Benchmark results are barely affected though.
