### PR TITLE
Capture caller's thread information into `LogInfo`

### DIFF
--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, object? context = null, string? memberName = null, string? filePath = null, int lineNumber = 0)
+public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, int threadId, bool isThreadPoolThread, object? context = null, string? memberName = null, string? filePath = null, int lineNumber = 0)
 {
     public readonly LogCategory Category = category;
     public readonly Timestamp Timestamp = timestamp;
@@ -12,6 +12,8 @@ public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLev
     public readonly EventId EventId = eventId;
     public readonly Exception? Exception = exception;
     public readonly LogScopeState? ScopeState = scopeState;
+    public readonly int ThreadId = threadId;
+    public readonly bool IsThreadPoolThread = isThreadPoolThread;
     public readonly object? Context = context;
     public readonly string? MemberName = memberName;
     public readonly string? FilePath = filePath;

--- a/src/ZLogger/LogInfo.cs
+++ b/src/ZLogger/LogInfo.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace ZLogger;
 
-public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, int threadId, bool isThreadPoolThread, object? context = null, string? memberName = null, string? filePath = null, int lineNumber = 0)
+public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLevel logLevel, EventId eventId, Exception? exception, LogScopeState? scopeState, ThreadInfo? threadInfo, object? context = null, string? memberName = null, string? filePath = null, int lineNumber = 0)
 {
     public readonly LogCategory Category = category;
     public readonly Timestamp Timestamp = timestamp;
@@ -12,8 +12,7 @@ public readonly struct LogInfo(LogCategory category, Timestamp timestamp, LogLev
     public readonly EventId EventId = eventId;
     public readonly Exception? Exception = exception;
     public readonly LogScopeState? ScopeState = scopeState;
-    public readonly int ThreadId = threadId;
-    public readonly bool IsThreadPoolThread = isThreadPoolThread;
+    public readonly ThreadInfo? ThreadInfo = threadInfo;
     public readonly object? Context = context;
     public readonly string? MemberName = memberName;
     public readonly string? FilePath = filePath;
@@ -39,4 +38,11 @@ public readonly struct LogCategory
     {
         return Name;
     }
+}
+
+public readonly struct ThreadInfo(int threadId, string? threadName, bool isThreadPoolThread)
+{
+    public readonly int ThreadId = threadId;
+    public readonly string? ThreadName = threadName;
+    public readonly bool IsThreadPoolThread = isThreadPoolThread;
 }

--- a/src/ZLogger/ZLoggerOptions.cs
+++ b/src/ZLogger/ZLoggerOptions.cs
@@ -13,7 +13,7 @@ public enum BackgroundBufferFullMode
     /// Wait until there's more room in the queue.
     /// </summary>
     Block,
-    
+
     /// <summary>
     /// Drop the overflowing log entry.
     /// </summary>
@@ -56,6 +56,11 @@ public class ZLoggerOptions
     /// Fallback of standard logger.Log, message stringify immediately or not. Default is true.
     /// </summary>
     public bool IsFormatLogImmediatelyInStandardLog { get; set; } = true;
+
+    /// <summary>
+    /// Capture information about the thread that generated a log entry. Default is false.
+    /// </summary>
+    public bool CaptureThreadInfo { get; set; } = false;
 
     Func<IZLoggerFormatter> formatterFactory = DefaultFormatterFactory;
 

--- a/tests/ZLogger.Tests/CallerInfoTest.cs
+++ b/tests/ZLogger.Tests/CallerInfoTest.cs
@@ -12,7 +12,11 @@ public class LogCallerInfoTest
         var loggerFactory = LoggerFactory.Create(x =>
         {
             x.SetMinimumLevel(LogLevel.Debug);
-            x.AddZLoggerLogProcessor(_ => processor);
+            x.AddZLoggerLogProcessor(options =>
+            {
+                options.CaptureThreadInfo = true;
+                return processor;
+            });
         });
         var logger = loggerFactory.CreateLogger("test");
 
@@ -21,9 +25,12 @@ public class LogCallerInfoTest
         var x = processor.Entries.Dequeue();
         x.LogInfo.MemberName.Should().Be("CallerInfo");
         Path.GetFileName(x.LogInfo.FilePath).Should().Be("CallerInfoTest.cs");
-        x.LogInfo.LineNumber.Should().Be(19);
-        x.LogInfo.ThreadId.Should().Be(System.Environment.CurrentManagedThreadId);
-        x.LogInfo.IsThreadPoolThread.Should().Be(true);
+        x.LogInfo.LineNumber.Should().Be(23);
+
+        x.LogInfo.ThreadInfo.Should().NotBeNull();
+        x.LogInfo.ThreadInfo!.Value.ThreadId.Should().Be(System.Environment.CurrentManagedThreadId);
+        x.LogInfo.ThreadInfo!.Value.IsThreadPoolThread.Should().Be(true);
+        x.LogInfo.ThreadInfo!.Value.ThreadName.Should().Be(".NET TP Worker");
     }
 }
 

--- a/tests/ZLogger.Tests/CallerInfoTest.cs
+++ b/tests/ZLogger.Tests/CallerInfoTest.cs
@@ -22,5 +22,8 @@ public class LogCallerInfoTest
         x.LogInfo.MemberName.Should().Be("CallerInfo");
         Path.GetFileName(x.LogInfo.FilePath).Should().Be("CallerInfoTest.cs");
         x.LogInfo.LineNumber.Should().Be(19);
+        x.LogInfo.ThreadId.Should().Be(System.Environment.CurrentManagedThreadId);
+        x.LogInfo.IsThreadPoolThread.Should().Be(true);
     }
 }
+


### PR DESCRIPTION
We have a use case to know which thread generated a log entry. The use of `IAsyncLogProcessor` alongside `System.Threading.Channels` means this has to be done when the `LogInfo` is generated rather than in the reader thread

Cleaned up some minor use of `is` combined with casting, which is not needed these days