### PR TITLE
Fix HTML-sensitive characters (like '<' and '>') are escaped

### DIFF
--- a/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
+++ b/src/ZLogger/Formatters/SystemTextJsonZLoggerFormatter.cs
@@ -117,7 +117,7 @@ namespace ZLogger.Formatters
         {
             WriteIndented = false,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
         public JsonLogInfoFormatter? AdditionalFormatter { get; set; }


### PR DESCRIPTION
After fixing #184, some characters are still escaped.

Examples: <, >, +