### PR TITLE
ZLOG0191: Use IFormattable instead of ISpanFormattable

### DIFF
--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -255,8 +255,7 @@ namespace ZLogger
                         }
                         else if (p.BoxedValue is IEnumerable enumerable)
                         {
-#if NET8_0
-                            if (p.BoxedValue is ISpanFormattable spanFormattable)
+                            if (p.BoxedValue is IFormattable)
                             {
                                 stringWriter.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
                             }
@@ -264,9 +263,6 @@ namespace ZLogger
                             {
                                 CodeGeneratorUtil.AppendAsJson(ref stringWriter, p.BoxedValue, p.Type);
                             }
-#else
-                            CodeGeneratorUtil.AppendAsJson(ref stringWriter, p.BoxedValue, p.Type);
-#endif
                         }
                         else
                         {


### PR DESCRIPTION
Fix for ZLOG0191, where ISpanFormattable was not supported by Unity's C# version, leading to their being no way to make
ZLoggerInterpolatedStringHandler use stringWriter.AppendFormatted for IEnumerables (and crashing trying to use AppendAsJson)