### PR TITLE
ZLOG0191: Use IFormattable instead of ISpanFormattable

### DIFF
--- a/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
+++ b/src/ZLogger/ZLoggerInterpolatedStringHandler.cs
@@ -303,7 +303,6 @@ namespace ZLogger
                         }
                         else if (p.BoxedValue is IEnumerable enumerable)
                         {
-#if NET8_0
                             if (p.BoxedValue is IFormattable)
                             {
                                 stringHandler.AppendFormatted(p.BoxedValue, p.Alignment, p.Format);
@@ -313,10 +312,6 @@ namespace ZLogger
                                 var jsonString = JsonSerializer.Serialize(p.BoxedValue, p.Type);
                                 stringHandler.AppendLiteral(jsonString);
                             }
-#else
-                            var jsonString = JsonSerializer.Serialize(p.BoxedValue, p.Type);
-                            stringHandler.AppendLiteral(jsonString);
-#endif
                         }
                         else
                         {


### PR DESCRIPTION
Remove net8.0 check for magicbox ToString IFormattable check

Unfortunately the previous fix didn't fully address this issue. When I was testing locally I was building the dll with net8.0 so everything was working as expected, so I didn't update this case, but the build released to NuGet, while supporting net8.0, doesn't apparently have NET8_0 defined when built so it still falls back into the JSON serializer instead of checking for IFormattable and appending as formatted.

Updated pull request with that check removed.