### PR TITLE
ci: Pinning third party GitHub Actions sha

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly" # Check for updates to GitHub Actions every week
+    ignore:
+      # I just want update action when major/minor version is updated. patch updates are too noisy.
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: dotnet build -c Debug
       - run: dotnet test -c Debug --no-build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
         with:
           dotnet-version: |

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -10,6 +10,6 @@ jobs:
     name: TOC Generator
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/toc-generator@v4.3.1
+      - uses: technote-space/toc-generator@9e238e7974de5fcf7b17b7acc54c896160dda0a3 # v4.3.1
         with:
           TOC_TITLE: "## Table of Contents"


### PR DESCRIPTION
## tl;dr;

Follow to the GitHub recommendation pinning third party actions sha.