### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
@@ -19,7 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 
 </Project>

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -1,31 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
-		<PackageReference Include="log4net" Version="2.0.15" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-		<PackageReference Include="NLog" Version="5.2.5" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.5" />
-		<PackageReference Include="Serilog" Version="3.1.1" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
-		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
-		<PackageReference Include="System.IO.Hashing" Version="8.0.0" />
-		<PackageReference Include="ZeroLog" Version="2.2.0" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
-		<ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
-			<OutputItemType>Analyzer</OutputItemType>
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="NLog" Version="5.2.5" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.5" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
+    <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="ZeroLog" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
+    <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -1,37 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="ConsoleAppFramework" Version="5.2.1">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="JetBrains.Profiler.Api" Version="1.4.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.8">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ConsoleAppFramework" Version="5.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<AdditionalFiles Include="BannedSymbols.txt" />
-	</ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ZLogger.MessagePack\ZLogger.MessagePack.csproj" />
-		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
-		<ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
-			<OutputItemType>Analyzer</OutputItemType>
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZLogger.MessagePack\ZLogger.MessagePack.csproj" />
+    <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
+    <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 
 </Project>

--- a/sandbox/GeneratorSandbox/GeneratorSandbox.csproj
+++ b/sandbox/GeneratorSandbox/GeneratorSandbox.csproj
@@ -1,25 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<LangVersion>12</LangVersion>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="MessagePack" Version="2.5.187" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="2.5.187" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
-		<ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
-			<OutputItemType>Analyzer</OutputItemType>
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
+    <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 
 </Project>

--- a/src/ZLogger.Generator/ZLogger.Generator.csproj
+++ b/src/ZLogger.Generator/ZLogger.Generator.csproj
@@ -1,36 +1,36 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>12</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<AnalyzerLanguage>cs</AnalyzerLanguage>
-		<DefineConstants>ZLOGGER_GENERATOR</DefineConstants>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<PackageId>ZLogger.Generator</PackageId>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <DefineConstants>ZLOGGER_GENERATOR</DefineConstants>
+    <Nullable>enable</Nullable>
 
-		<IsRoslynComponent>true</IsRoslynComponent>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<!-- We don't need to publish the package to NuGet. bundled with ZLogger  -->
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-	<ItemGroup>
-		<Compile Include="..\ZLogger\ZLoggerMessageAttribtue.cs" Link="ZLoggerMessageAttribtue.cs" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="../../Icon.png" Pack="true" PackagePath="/" />
-		<None Include="ZLoggerGenerator.Emitter.cs" />
-		<None Include="ZLoggerGenerator.Parser.cs" />
+    <!-- We don't need to publish the package to NuGet. bundled with ZLogger  -->
+    <IsPackable>false</IsPackable>
+    <PackageId>ZLogger.Generator</PackageId>
+  </PropertyGroup>
 
-		<!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
-		<!-- require to support SyntaxValueProvider.ForAttributeWithMetadataName(Roslyn 4.3.1, VS2022 17.3 -->
-		<!-- Unity 2022.2 or newer is 4.1.0. -->
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ZLogger\ZLoggerMessageAttribtue.cs" Link="ZLoggerMessageAttribtue.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
+    <None Include="ZLoggerGenerator.Emitter.cs" />
+    <None Include="ZLoggerGenerator.Parser.cs" />
+
+    <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
+    <!-- require to support SyntaxValueProvider.ForAttributeWithMetadataName(Roslyn 4.3.1, VS2022 17.3 -->
+    <!-- Unity 2022.2 or newer is 4.1.0. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/ZLogger.MessagePack/ZLogger.MessagePack.csproj
+++ b/src/ZLogger.MessagePack/ZLogger.MessagePack.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>12</LangVersion>
 
-        <!-- NuGet Packaging -->
-        <PackageTags>logging;messagepack;</PackageTags>
-        <Description>ZLogger plugin to format log results as messagepack.</Description>
-    </PropertyGroup>
+    <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
+    <PackageTags>logging;messagepack;</PackageTags>
+    <Description>ZLogger plugin to format log results as messagepack.</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-		<None Include="../../Icon.png" Pack="true" PackagePath="/" />
-        <InternalsVisibleTo Include="ZLogger.MessagePack.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000144ec28f1e9ef7b17dacc47425a7a153aea0a7baa590743a2d1a86f4b3e10a8a12712c6e647966bfd8bd6e830048b23bd42bbc56f179585c15b8c19cf86c0eed1b73c993dd7a93a30051dd50fdda0e4d6b65e6874e30f1c37cf8bcbc7fe02c7f2e6a0a3327c0ccc1631bf645f40732521fa0b41a30c178d08f7dd779d42a1ee" />        
-    </ItemGroup>
-    
-    <ItemGroup>
-        <ProjectReference Include="..\ZLogger\ZLogger.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="MessagePack" Version="2.5.187" />
-        <PackageReference Include="PolySharp" Version="1.13.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="ZLogger.MessagePack.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000144ec28f1e9ef7b17dacc47425a7a153aea0a7baa590743a2d1a86f4b3e10a8a12712c6e647966bfd8bd6e830048b23bd42bbc56f179585c15b8c19cf86c0eed1b73c993dd7a93a30051dd50fdda0e4d6b65e6874e30f1c37cf8bcbc7fe02c7f2e6a0a3327c0ccc1631bf645f40732521fa0b41a30c178d08f7dd779d42a1ee" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ZLogger\ZLogger.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="2.5.187" />
+    <PackageReference Include="PolySharp" Version="1.13.2">
+     <PrivateAssets>all</PrivateAssets>
+     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/ZLogger/ZLogger.csproj
+++ b/src/ZLogger/ZLogger.csproj
@@ -1,95 +1,94 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
-		<Nullable>enable</Nullable>
-		<LangVersion>12.0</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<NoWarn>1701;1702;1591;1573</NoWarn>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1591;1573</NoWarn>
 
     <!-- Enable for using [DynamicallyAccessedMembers] attribute -->
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
 
     <!-- NuGet Packaging -->
-		<PackageTags>logging;</PackageTags>
-		<Description>Zero Allocation Text/Strcutured Logger for .NET Core, built on top of a Microsoft.Extensions.Logging.</Description>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <PackageTags>logging;</PackageTags>
+    <Description>Zero Allocation Text/Strcutured Logger for .NET Core, built on top of a Microsoft.Extensions.Logging.</Description>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
+  <PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
     <!-- Enable AOT analyzers -->
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-		<EmbeddedResource Include="..\..\LICENSE" />
-		<InternalsVisibleTo Include="ZLogger.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000144ec28f1e9ef7b17dacc47425a7a153aea0a7baa590743a2d1a86f4b3e10a8a12712c6e647966bfd8bd6e830048b23bd42bbc56f179585c15b8c19cf86c0eed1b73c993dd7a93a30051dd50fdda0e4d6b65e6874e30f1c37cf8bcbc7fe02c7f2e6a0a3327c0ccc1631bf645f40732521fa0b41a30c178d08f7dd779d42a1ee" />
-	</ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="ZLogger.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000144ec28f1e9ef7b17dacc47425a7a153aea0a7baa590743a2d1a86f4b3e10a8a12712c6e647966bfd8bd6e830048b23bd42bbc56f179585c15b8c19cf86c0eed1b73c993dd7a93a30051dd50fdda0e4d6b65e6874e30f1c37cf8bcbc7fe02c7f2e6a0a3327c0ccc1631bf645f40732521fa0b41a30c178d08f7dd779d42a1ee" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="System.Threading.Channels" Version="8.0.0" />
-		<PackageReference Include="System.IO.Hashing" Version="8.0.0" />
-		<PackageReference Include="Utf8StringInterpolation" Version="1.3.1" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="Utf8StringInterpolation" Version="1.3.1" />
+  </ItemGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
-	</ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+  </ItemGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' Or $(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-		<PackageReference Include="PolySharp" Version="1.14.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' Or $(TargetFramework) == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="PolySharp" Version="1.14.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- Bundle SourceGenerator -->
-	<ItemGroup>
-		<ProjectReference Include="..\ZLogger.Generator\ZLogger.Generator.csproj" ReferenceOutputAssembly="false" />
-		<None Include="..\ZLogger.Generator\bin\$(Configuration)\netstandard2.0\ZLogger.Generator.dll" PackagePath="analyzers\dotnet\roslyn4.3\cs" Pack="true" Visible="false" />
-	</ItemGroup>
+  <!-- Bundle SourceGenerator -->
+  <ItemGroup>
+    <ProjectReference Include="..\ZLogger.Generator\ZLogger.Generator.csproj" ReferenceOutputAssembly="false" />
+    <None Include="..\ZLogger.Generator\bin\$(Configuration)\netstandard2.0\ZLogger.Generator.dll" PackagePath="analyzers\dotnet\roslyn4.3\cs" Pack="true" Visible="false" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Update="MessageTemplate.Format.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>MessageTemplate.Format.cs</LastGenOutput>
-		</None>
-		<None Update="ZLoggerExtensions.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>ZLoggerExtensions.cs</LastGenOutput>
-		</None>
-		<None Update="ZLoggerInterpolatedStringHandler.LogLevel.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>ZLoggerInterpolatedStringHandler.LogLevel.cs</LastGenOutput>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Update="MessageTemplate.Format.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MessageTemplate.Format.cs</LastGenOutput>
+    </None>
+    <None Update="ZLoggerExtensions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ZLoggerExtensions.cs</LastGenOutput>
+    </None>
+    <None Update="ZLoggerInterpolatedStringHandler.LogLevel.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ZLoggerInterpolatedStringHandler.LogLevel.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Update="MessageTemplate.Format.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>MessageTemplate.Format.tt</DependentUpon>
-		</Compile>
-		<Compile Update="ZLoggerExtensions.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ZLoggerExtensions.tt</DependentUpon>
-		</Compile>
-		<Compile Update="ZLoggerInterpolatedStringHandler.LogLevel.cs">
-			<AutoGen>True</AutoGen>
-			<DesignTime>True</DesignTime>
-			<DependentUpon>ZLoggerInterpolatedStringHandler.LogLevel.tt</DependentUpon>
-		</Compile>
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Update="MessageTemplate.Format.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MessageTemplate.Format.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ZLoggerExtensions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ZLoggerExtensions.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ZLoggerInterpolatedStringHandler.LogLevel.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>ZLoggerInterpolatedStringHandler.LogLevel.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-	</ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
 </Project>

--- a/tests/ZLogger.Generator.Tests/ZLogger.Generator.Tests.csproj
+++ b/tests/ZLogger.Generator.Tests/ZLogger.Generator.Tests.csproj
@@ -1,40 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.7.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-		<PackageReference Include="Utf8StringInterpolation" Version="1.3.1" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Utf8StringInterpolation" Version="1.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
-		<ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj" />
-		<ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
-			<OutputItemType>Analyzer</OutputItemType>
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		</ProjectReference>
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
+    <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj" />
+    <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 
 
-	<ItemGroup>
-		<Using Include="Xunit" />
-		<Using Include="Xunit.Abstractions" />
-		<Using Include="ZLogger" />
-		<Using Include="FluentAssertions" />
-		<Using Include="Microsoft.Extensions.Logging" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+    <Using Include="ZLogger" />
+    <Using Include="FluentAssertions" />
+    <Using Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
 </Project>

--- a/tests/ZLogger.MessagePack.Tests/ZLogger.MessagePack.Tests.csproj
+++ b/tests/ZLogger.MessagePack.Tests/ZLogger.MessagePack.Tests.csproj
@@ -1,30 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="MessagePack" Version="2.5.187" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\ZLogger.MessagePack\ZLogger.MessagePack.csproj" />
-      <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
-      <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj" />
-      <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
-          <OutputItemType>Analyzer</OutputItemType>
-          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      </ProjectReference>
-    </ItemGroup>
+  <ItemGroup>
+   <ProjectReference Include="..\..\src\ZLogger.MessagePack\ZLogger.MessagePack.csproj" />
+   <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
+   <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj" />
+   <ProjectReference Include="..\..\src\ZLogger.Generator\ZLogger.Generator.csproj">
+     <OutputItemType>Analyzer</OutputItemType>
+     <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+   </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/tests/ZLogger.Tests/ZLogger.Tests.csproj
+++ b/tests/ZLogger.Tests/ZLogger.Tests.csproj
@@ -1,34 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<IsPackable>false</IsPackable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.7.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZLogger\ZLogger.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Using Include="Xunit" />
-		<Using Include="Xunit.Abstractions" />
-		<Using Include="ZLogger" />
-		<Using Include="FluentAssertions" />
-		<Using Include="Microsoft.Extensions.Logging" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+    <Using Include="ZLogger" />
+    <Using Include="FluentAssertions" />
+    <Using Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
 </Project>

--- a/tools/CommandTools/CommandTools.csproj
+++ b/tools/CommandTools/CommandTools.csproj
@@ -1,14 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="ConsoleAppFramework" Version="4.2.4" />
-		<PackageReference Include="Markdig" Version="0.18.3" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ConsoleAppFramework" Version="4.2.4" />
+    <PackageReference Include="Markdig" Version="0.18.3" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
