### PR TITLE
ZLOG0228: fix for nulls in interpolated strings throwing

### DIFF
--- a/src/ZLogger/Internal/MagicalBox.cs
+++ b/src/ZLogger/Internal/MagicalBox.cs
@@ -72,9 +72,10 @@ internal unsafe partial struct MagicalBox
         return ReaderCache.ReadBoxed(type, this, offset);
     }
 
-    public bool TryReadTo(Type type, int offset, int alignment, string? format, ref Utf8StringWriter<IBufferWriter<byte>> handler)
+    public bool TryReadTo(Type? type, int offset, int alignment, string? format, ref Utf8StringWriter<IBufferWriter<byte>> handler)
     {
         if (offset < 0) return false;
+        if (type == null) return false;
         if (type.IsEnum) goto USE_READER;
 
         var code = Type.GetTypeCode(type);


### PR DESCRIPTION
Fix for ZLOG0228: Handle null values in Interpolated strings, just check for a null on the type and return false.